### PR TITLE
Update DOI and version to v0.1.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,9 @@ authors:
     email: hsugawa@gmail.com
 repository-code: "https://github.com/hsugawa8651/BoltzTraP.jl"
 license: GPL-3.0-or-later
-version: 0.1.0
-date-released: 2026-01-15
-doi: "10.5281/zenodo.18253186"
+version: 0.1.1
+date-released: 2026-01-21
+doi: "10.5281/zenodo.18328895"
 keywords:
   - band structure
   - interpolation

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Bug reports and feature requests are welcome via [GitHub Issues](https://github.
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.1.0) [Computer software]. https://doi.org/10.5281/zenodo.18253186
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.1.1) [Computer software]. https://doi.org/10.5281/zenodo.18328895
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -18,10 +18,10 @@ authors:
 affiliations:
   - name: Graduate School of Systems Design, Tokyo Metropolitan University, Japan
     index: 1
-date: 7 January 2026
+date: 21 January 2026
 bibliography: paper.bib
 repository: https://github.com/hsugawa8651/BoltzTraP.jl
-archive_doi: 10.5281/zenodo.18253186
+archive_doi: 10.5281/zenodo.18328895
 ---
 
 # Summary


### PR DESCRIPTION
## Summary
- Update archive_doi in paper.md for v0.1.1 Zenodo release
- Update CITATION.cff with new version, date, and DOI
- Update README.md citation with new version and DOI

**New DOI**: `10.5281/zenodo.18328895`