### PR TITLE
Update DOI references for v0.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ repository-code: "https://github.com/hsugawa8651/BoltzTraP.jl"
 license: GPL-3.0-or-later
 version: 0.2.0
 date-released: 2026-02-11
-doi: "10.5281/zenodo.18335645"
+doi: "10.5281/zenodo.18605978"
 keywords:
   - band structure
   - interpolation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/hsugawa8651/BoltzTraP.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/hsugawa8651/BoltzTraP.jl/actions/workflows/CI.yml)
 [![Documentation](https://github.com/hsugawa8651/BoltzTraP.jl/actions/workflows/docs.yml/badge.svg)](https://hsugawa8651.github.io/BoltzTraP.jl)
 [![codecov](https://codecov.io/gh/hsugawa8651/BoltzTraP.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/hsugawa8651/BoltzTraP.jl)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18335645.svg)](https://doi.org/10.5281/zenodo.18335645)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18605978.svg)](https://doi.org/10.5281/zenodo.18605978)
 
 Julia port of [BoltzTraP2 v25.11.1](https://pypi.org/project/BoltzTraP2/25.11.1/) ([source](https://gitlab.com/sousaw/BoltzTraP2)), a band structure interpolation and transport coefficient calculator.
 
@@ -74,7 +74,7 @@ Bug reports and feature requests are welcome via [GitHub Issues](https://github.
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.2.0) [Computer software]. https://doi.org/10.5281/zenodo.18335645
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.2.0) [Computer software]. https://doi.org/10.5281/zenodo.18605978
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -96,7 +96,7 @@ Key differences:
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.2.0) [Computer software]. [doi:10.5281/zenodo.18335645](https://doi.org/10.5281/zenodo.18335645)
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.2.0) [Computer software]. [doi:10.5281/zenodo.18605978](https://doi.org/10.5281/zenodo.18605978)
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -21,7 +21,7 @@ affiliations:
 date: 22 January 2026
 bibliography: paper.bib
 repository: https://github.com/hsugawa8651/BoltzTraP.jl
-archive_doi: 10.5281/zenodo.18335645
+archive_doi: 10.5281/zenodo.18605978
 ---
 
 # Summary
@@ -168,7 +168,7 @@ The test suite includes:
 
 Full documentation is available at: https://hsugawa8651.github.io/BoltzTraP.jl/
 
-This paper describes version 0.2.0, archived at Zenodo (DOI: 10.5281/zenodo.18335645).
+This paper describes version 0.2.0, archived at Zenodo (DOI: 10.5281/zenodo.18605978).
 
 Installation via Julia's package manager:
 


### PR DESCRIPTION
## Summary
- Update Zenodo DOI from v0.1.2 (10.5281/zenodo.18335645) to v0.2.0 (10.5281/zenodo.18605978)
- Updated files: CITATION.cff, README.md, docs/src/index.md, paper/paper.md