### PR TITLE
Fix stable docs not updating on TagBot release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
       - main
     tags: '*'
   pull_request:
+  release:
+    types: [created]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Add `release: types: [created]` trigger to docs workflow
- TagBot's `GITHUB_TOKEN` does not trigger `push: tags` events (GitHub restriction)
- The `release` event is not subject to this restriction

## Note
- v0.3.0 stable docs remain at v0.2.1 (accepted; will update at v0.3.1)
- Zenodo DOI is tied to original v0.3.0 commit, so tag re-creation is avoided

Closes #29