### PR TITLE
Prepare v0.3.1 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     email: hsugawa@gmail.com
 repository-code: "https://github.com/hsugawa8651/BoltzTraP.jl"
 license: GPL-3.0-or-later
-version: 0.3.0
-date-released: 2026-03-05
+version: 0.3.1
+date-released: 2026-04-27
 doi: "10.5281/zenodo.18606114"
 keywords:
   - band structure

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "BoltzTraP"
 uuid = "cbda18ea-c181-4d25-a1c9-354b8a2900c6"
 license = "GPL-3.0-or-later"
 authors = ["Hiroharu Sugawara <hsugawa@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -26,14 +26,12 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Brillouin = "23470ee3-d0df-4052-8b1a-8cbd6363e7f0"
 DFTK = "acf6eb54-70d9-11e9-0013-234b7a5f5337"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [extensions]
 BoltzTraPDFTKExt = "DFTK"
 BoltzTraPNCDatasetsExt = "NCDatasets"
 BoltzTraPPlotsExt = ["Plots", "Brillouin"]
-BoltzTraPPythonPlotExt = "PythonPlot"
 BoltzTraPRecipesBaseExt = "RecipesBase"
 
 [compat]
@@ -51,7 +49,6 @@ NCDatasets = "0.14"
 NPZ = "0.4"
 Plots = "1.41.3"
 PseudoPotentialData = "0.2.4"
-PythonPlot = "1"
 RecipesBase = "1"
 Spglib = "1"
 StaticArrays = "1"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Bug reports and feature requests are welcome via [GitHub Issues](https://github.
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.0) [Computer software]. https://doi.org/10.5281/zenodo.18606114
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.1) [Computer software]. https://doi.org/10.5281/zenodo.18606114
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,7 +102,7 @@ Key differences:
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.0) [Computer software]. [doi:10.5281/zenodo.18606114](https://doi.org/10.5281/zenodo.18606114)
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.1) [Computer software]. [doi:10.5281/zenodo.18606114](https://doi.org/10.5281/zenodo.18606114)
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)


### PR DESCRIPTION
Refs #41

## Test plan
- [x] Local `Pkg.test()`: 5949/5949 pass (1m49s on macOS aarch64)
- [x] CI green on Julia 1.10 / 1.11 x ubuntu-latest / macOS-aarch64
- [x] CI docs build green
- [x] Verify `using BoltzTraP; using PythonPlot` does not raise unresolved-extension errors after the declaration removal