### PR TITLE
Update DOI to v0.3.1 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ repository-code: "https://github.com/hsugawa8651/BoltzTraP.jl"
 license: GPL-3.0-or-later
 version: 0.3.1
 date-released: 2026-04-27
-doi: "10.5281/zenodo.18606114"
+doi: "10.5281/zenodo.19832309"
 keywords:
   - band structure
   - interpolation

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/hsugawa8651/BoltzTraP.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/hsugawa8651/BoltzTraP.jl/actions/workflows/CI.yml)
 [![Documentation](https://github.com/hsugawa8651/BoltzTraP.jl/actions/workflows/docs.yml/badge.svg)](https://hsugawa8651.github.io/BoltzTraP.jl)
 [![codecov](https://codecov.io/gh/hsugawa8651/BoltzTraP.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/hsugawa8651/BoltzTraP.jl)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18606114.svg)](https://doi.org/10.5281/zenodo.18606114)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18253185.svg)](https://doi.org/10.5281/zenodo.18253185)
 
 Julia port of [BoltzTraP2 v25.11.1](https://pypi.org/project/BoltzTraP2/25.11.1/) ([source](https://gitlab.com/sousaw/BoltzTraP2)), a band structure interpolation and transport coefficient calculator.
 
@@ -95,7 +95,7 @@ Bug reports and feature requests are welcome via [GitHub Issues](https://github.
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.1) [Computer software]. https://doi.org/10.5281/zenodo.18606114
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.1) [Computer software]. https://doi.org/10.5281/zenodo.19832309
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,7 +102,7 @@ Key differences:
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.1) [Computer software]. [doi:10.5281/zenodo.18606114](https://doi.org/10.5281/zenodo.18606114)
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.1) [Computer software]. [doi:10.5281/zenodo.19832309](https://doi.org/10.5281/zenodo.19832309)
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)


### PR DESCRIPTION
Refs #41

## Test plan
- [ ] CI green on Julia 1.10 / 1.11 x ubuntu-latest / macOS-aarch64
- [ ] CI docs build green
- [ ] Verify Concept DOI badge link resolves: https://doi.org/10.5281/zenodo.18253185
- [ ] Verify Version DOI citation link resolves: https://doi.org/10.5281/zenodo.19832309