### PR TITLE
ci: Add format-check workflow

### DIFF
--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,0 +1,28 @@
+name: Format
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v2
+      - name: Install JuliaFormatter
+        run: julia -e 'using Pkg; Pkg.add(name="JuliaFormatter", version="2")'
+      - name: Check format
+        run: |
+          julia -e '
+            using JuliaFormatter
+            formatted = format(".", verbose=true)
+            if !formatted
+              println(stderr, "Some files would be reformatted by JuliaFormatter.")
+              println(stderr, "Run `julia -e \"using JuliaFormatter; format(\\\".\\\")\"` locally and commit the result.")
+              exit(1)
+            end'


### PR DESCRIPTION
Closes #49

## Test plan
- [x] Local `format(".")` returns true (no changes) on current main
- [ ] CI green on the new Format.yml workflow
- [ ] Verify Format.yml fires on push and pull_request events

## Note on issue #49

Issue #49 listed "no `.JuliaFormatter.toml` config" as a problem, but
the file has actually been present since v0.1.0 (commit dc9dde3). The
real cause of the format drift surfaced in #50 was the lack of CI
enforcement, which this PR addresses.