### PR TITLE
ci: Use SSH key in TagBot to trigger docs deployment on release

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -14,3 +14,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Test plan
- [x] Diff is a 1-line addition to `.github/workflows/TagBot.yml`
- [x] CI green on this PR
- [x] Verify on next release that `docs.yml` auto-fires from tag push (no need for `gh workflow run docs.yml --ref vX.Y.Z` manual dispatch)