### PR TITLE
feat: method-dispatched transport API (AbstractBZSampling + TransportSystem)

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -30,6 +30,7 @@ makedocs(
             "Conventions" => "conventions.md",
             "Functional Tests" => "ftest.md",
         ],
+        "Architecture" => "architecture.md",
         "Magnetic Materials" => "magnetic.md",
         "Validation" => "validation.md",
         "Benchmarks" => "benchmarks.md",

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -1,0 +1,75 @@
+# Architecture
+
+This page describes BoltzTraP.jl's transport API design, in particular
+the dispatch axes that allow swapping the BZ sampling and band
+interpolation strategies independently.
+
+## Method-dispatched transport API
+
+The primary entry point for transport coefficient computation is
+`solve_transport`, which dispatches on three independent axes:
+`sampling::AbstractBZSampling`, `interp::AbstractInterpolator`, and
+`sys::TransportSystem`.
+
+```@docs
+solve_transport
+```
+
+| Axis | Abstract type | Concrete subtype(s) | Role |
+|---|---|---|---|
+| `sampling` | `AbstractBZSampling` | `UniformMesh` | How the BZ is sampled |
+| `interp` | `AbstractInterpolator` | `FourierInterpolator` | How band energies and velocities are evaluated |
+| `sys` | `TransportSystem` | (concrete struct) | Material data carrier |
+
+A new sampling or interpolator strategy can be added by introducing a
+new concrete subtype and a new `solve_transport` method dispatched on
+that combination — no changes to existing types or to the entry point.
+
+## BZ sampling
+
+```@docs
+AbstractBZSampling
+UniformMesh
+```
+
+## Material data carrier
+
+`TransportSystem` collects material-dependent data that was previously
+scattered across `InterpolationResult.metadata` and `BandData{ST}`:
+
+```@docs
+TransportSystem
+```
+
+The `TransportSystem(::InterpolationResult)` convenience constructor
+extracts these fields from existing interpolation output, so callers
+that already have an `InterpolationResult` need not assemble the struct
+manually.
+
+## Backward compatibility
+
+The legacy entry points
+
+```julia
+run_integrate(interp::InterpolationResult; kwargs...)
+run_integrate(interp::InterpolationResult, mur::AbstractVector; kwargs...)
+```
+
+are preserved as thin wrappers. They build a `TransportSystem` and
+`FourierInterpolator` from the `InterpolationResult` and delegate to
+`solve_transport(UniformMesh(), ...)`. The wrapper restores the original
+`metadata["source"]` value after the delegate returns. Output is
+bit-equal to the pre-refactor implementation under default arguments.
+
+## Provenance metadata
+
+`TransportResult.metadata` records which sampling and interpolator types
+produced the output:
+
+| Key | Example value | Source |
+|---|---|---|
+| `"sampling"` | `"UniformMesh"` | type name of the sampling argument |
+| `"interpolator"` | `"Fourier"` | type name of the interpolator argument with the `Interpolator` suffix stripped |
+
+These keys are stamped by `solve_transport` and survive JLD2 round-trip
+through `save_integrate` / `load_integrate`.

--- a/src/BoltzTraP.jl
+++ b/src/BoltzTraP.jl
@@ -61,6 +61,9 @@ include("io/loader.jl")  # Auto-detection (must be after format-specific loaders
 # High-level workflow
 include("workflow.jl")
 
+# Method-dispatched transport API (AbstractBZSampling axis)
+include("solve_transport.jl")
+
 # Plotting types (backend-independent)
 include("plottypes.jl")
 
@@ -99,6 +102,7 @@ include("cli.jl")
 
 # Workflow
 export run_interpolate, run_integrate
+export solve_transport
 
 # Types
 export InterpolationResult, TransportResult

--- a/src/BoltzTraP.jl
+++ b/src/BoltzTraP.jl
@@ -40,6 +40,9 @@ include("equivalences.jl")
 # Fourier interpolation
 include("interpolation.jl")
 
+# BZ sampling abstractions (dispatch axis for solve_transport)
+include("sampling.jl")
+
 # Band reconstruction via FFT
 include("reconstruction.jl")
 
@@ -100,6 +103,9 @@ export run_interpolate, run_integrate
 # Types
 export InterpolationResult, TransportResult
 export DFTData, NonMagneticData, SpinPolarizedData, nspin, is_magnetic
+
+# BZ sampling
+export AbstractBZSampling, UniformMesh
 
 # Spin types (v0.3 magnetic support)
 export SpinType, Unpolarized, Collinear, NonCollinear

--- a/src/BoltzTraP.jl
+++ b/src/BoltzTraP.jl
@@ -105,7 +105,7 @@ export InterpolationResult, TransportResult
 export DFTData, NonMagneticData, SpinPolarizedData, nspin, is_magnetic
 
 # BZ sampling
-export AbstractBZSampling, UniformMesh
+export AbstractBZSampling, UniformMesh, TransportSystem
 
 # Spin types (v0.3 magnetic support)
 export SpinType, Unpolarized, Collinear, NonCollinear

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -92,6 +92,30 @@ function interpolate(interp, kpoints)
     )
 end
 
+# Abstract-type fallback for AbstractInterpolator subtypes that lack a
+# concrete implementation. Without these, dispatch falls to the ::Any
+# fallback above and the error message states "expects a concrete subtype"
+# even when the caller passed a proper subtype, which is misleading. (Issue #54.)
+#
+# Note: `interpolate(::AbstractInterpolator, kpoints)` already exists above
+# (line 64) as the default delegate that calls `interpolate_bands` and
+# `interpolate_velocities`. For a subtype-without-impl, that delegate
+# cascades through the new abstract-type methods below, so a separate
+# abstract-type method for `interpolate` is not needed.
+function interpolate_bands(interp::AbstractInterpolator, kpoints)
+    error(
+        "interpolate_bands: not implemented for $(typeof(interp)). " *
+        "Subtypes of AbstractInterpolator must define their own method.",
+    )
+end
+
+function interpolate_velocities(interp::AbstractInterpolator, kpoints)
+    error(
+        "interpolate_velocities: not implemented for $(typeof(interp)). " *
+        "Subtypes of AbstractInterpolator must define their own method.",
+    )
+end
+
 # ============================================================================
 # Convenience Functions (Default to FourierInterpolator)
 # ============================================================================

--- a/src/io/serialization.jl
+++ b/src/io/serialization.jl
@@ -88,7 +88,8 @@ function TransportSystem(interp::InterpolationResult)
     fermi = interp.metadata["fermi"]
     nelect = interp.metadata["nelect"]
     dosweight = interp.metadata["dosweight"]
-    spintype_str = interp.metadata["spintype"]
+    # v0.1 metadata (pre-spintype era) defaults to Unpolarized.
+    spintype_str = get(interp.metadata, "spintype", "Unpolarized")
     spintype = if spintype_str == "Unpolarized"
         Unpolarized()
     elseif spintype_str == "Collinear"

--- a/src/io/serialization.jl
+++ b/src/io/serialization.jl
@@ -74,6 +74,34 @@ function InterpolationResult(
 end
 
 """
+    TransportSystem(interp::InterpolationResult) -> TransportSystem
+
+Build a [`TransportSystem`](@ref) from an `InterpolationResult`, extracting
+lattice (Bohr), Fermi energy (Ha), electron count, DOS weight, and spin type
+from the standard metadata keys.
+
+Required metadata keys: `"fermi"` (Ha), `"nelect"`, `"dosweight"`,
+`"spintype"` (`"Unpolarized"` / `"Collinear"` / `"NonCollinear"`).
+"""
+function TransportSystem(interp::InterpolationResult)
+    lat = SMatrix{3,3,Float64}(interp.lattvec)
+    fermi = interp.metadata["fermi"]
+    nelect = interp.metadata["nelect"]
+    dosweight = interp.metadata["dosweight"]
+    spintype_str = interp.metadata["spintype"]
+    spintype = if spintype_str == "Unpolarized"
+        Unpolarized()
+    elseif spintype_str == "Collinear"
+        Collinear()
+    elseif spintype_str == "NonCollinear"
+        NonCollinear()
+    else
+        error("TransportSystem: unknown spintype \"$spintype_str\" in metadata")
+    end
+    return TransportSystem(lat, fermi, nelect, dosweight, spintype)
+end
+
+"""
     TransportResult
 
 Container for transport coefficients from [`run_integrate`](@ref).

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 Hiroharu Sugawara
 # Part of BoltzTraP.jl
 
-#=
+"""
     AbstractBZSampling
 
 Abstract type for Brillouin-zone sampling strategies used by transport
@@ -12,10 +12,10 @@ that determine how `solve_transport` integrates over the BZ.
 This is the dispatch axis for BZ sampling strategies; alternative methods
 (adaptive grids, AutoBZ-style integration, wavelet meshes) can be added
 later as additional concrete subtypes.
-=#
+"""
 abstract type AbstractBZSampling end
 
-#=
+"""
     UniformMesh(nk=nothing)
     UniformMesh((nk1, nk2, nk3))
 
@@ -25,14 +25,14 @@ Uniform Monkhorst-Pack-style mesh. The `nk` field selects the mesh density:
     legacy `run_integrate` behavior, which derives the mesh from the
     interpolator's k-point density).
   - `nk::Tuple{Int,Int,Int}`: explicit user-specified mesh dimensions.
-=#
+"""
 struct UniformMesh <: AbstractBZSampling
     nk::Union{Nothing,Tuple{Int,Int,Int}}
 end
 
 UniformMesh() = UniformMesh(nothing)
 
-#=
+"""
     TransportSystem(lattice, fermi, nelect, dosweight, spintype)
     TransportSystem(interp::InterpolationResult)
 
@@ -51,7 +51,7 @@ Fields:
 
 The `TransportSystem(::InterpolationResult)` constructor is defined in
 `io/serialization.jl` (after `InterpolationResult` itself is defined).
-=#
+"""
 struct TransportSystem
     lattice::SMatrix{3,3,Float64,9}
     fermi::Float64

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of BoltzTraP.jl
+
+#=
+    AbstractBZSampling
+
+Abstract type for Brillouin-zone sampling strategies used by transport
+calculations. Concrete subtypes (e.g. `UniformMesh`) carry the parameters
+that determine how `solve_transport` integrates over the BZ.
+
+This is the dispatch axis for BZ sampling strategies; alternative methods
+(adaptive grids, AutoBZ-style integration, wavelet meshes) can be added
+later as additional concrete subtypes.
+=#
+abstract type AbstractBZSampling end
+
+#=
+    UniformMesh(nk=nothing)
+    UniformMesh((nk1, nk2, nk3))
+
+Uniform Monkhorst-Pack-style mesh. The `nk` field selects the mesh density:
+
+  - `nk === nothing`: the interpolator decides the mesh size (matches the
+    legacy `run_integrate` behavior, which derives the mesh from the
+    interpolator's k-point density).
+  - `nk::Tuple{Int,Int,Int}`: explicit user-specified mesh dimensions.
+=#
+struct UniformMesh <: AbstractBZSampling
+    nk::Union{Nothing,Tuple{Int,Int,Int}}
+end
+
+UniformMesh() = UniformMesh(nothing)

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -43,11 +43,12 @@ underlying band data; this struct unifies them as a single, dispatched
 data carrier for the new `solve_transport` API.
 
 Fields:
-- `lattice::SMatrix{3,3,Float64,9}`: 3×3 lattice vectors (columns) in Bohr
-- `fermi::Float64`: Fermi energy in Hartree
-- `nelect::Float64`: number of electrons per unit cell
-- `dosweight::Float64`: DOS weight (2.0 = non-magnetic, 1.0 = spin-polarized)
-- `spintype::SpinType`: `Unpolarized()` / `Collinear()` / `NonCollinear()`
+
+  - `lattice::SMatrix{3,3,Float64,9}`: 3×3 lattice vectors (columns) in Bohr
+  - `fermi::Float64`: Fermi energy in Hartree
+  - `nelect::Float64`: number of electrons per unit cell
+  - `dosweight::Float64`: DOS weight (2.0 = non-magnetic, 1.0 = spin-polarized)
+  - `spintype::SpinType`: `Unpolarized()` / `Collinear()` / `NonCollinear()`
 
 The `TransportSystem(::InterpolationResult)` constructor is defined in
 `io/serialization.jl` (after `InterpolationResult` itself is defined).

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -31,3 +31,31 @@ struct UniformMesh <: AbstractBZSampling
 end
 
 UniformMesh() = UniformMesh(nothing)
+
+#=
+    TransportSystem(lattice, fermi, nelect, dosweight, spintype)
+    TransportSystem(interp::InterpolationResult)
+
+System-level constants needed for transport calculations: lattice, Fermi
+energy, electron count, DOS weight, and spin type. These quantities are
+conventionally spread across `InterpolationResult.metadata` and the
+underlying band data; this struct unifies them as a single, dispatched
+data carrier for the new `solve_transport` API.
+
+Fields:
+- `lattice::SMatrix{3,3,Float64,9}`: 3×3 lattice vectors (columns) in Bohr
+- `fermi::Float64`: Fermi energy in Hartree
+- `nelect::Float64`: number of electrons per unit cell
+- `dosweight::Float64`: DOS weight (2.0 = non-magnetic, 1.0 = spin-polarized)
+- `spintype::SpinType`: `Unpolarized()` / `Collinear()` / `NonCollinear()`
+
+The `TransportSystem(::InterpolationResult)` constructor is defined in
+`io/serialization.jl` (after `InterpolationResult` itself is defined).
+=#
+struct TransportSystem
+    lattice::SMatrix{3,3,Float64,9}
+    fermi::Float64
+    nelect::Float64
+    dosweight::Float64
+    spintype::SpinType
+end

--- a/src/solve_transport.jl
+++ b/src/solve_transport.jl
@@ -65,6 +65,7 @@ function solve_transport(
     interp::FourierInterpolator,
     sys::TransportSystem;
     temperatures::AbstractVector{<:Real} = [300.0],
+    mur::Union{Nothing,AbstractVector{<:Real}} = nothing,
     bins::Int = 0,
     scissor::Union{Nothing,Real} = nothing,
     verbose::Bool = false,
@@ -90,15 +91,19 @@ function solve_transport(
     npts_dos = bins > 0 ? bins : 500
     epsilon, dos, vvdos = BTPDOS(eband, vvband; npts = npts_dos)
 
-    # Step 3: μ range (auto-generate from DOS grid)
-    margin = 9.0 * KB_AU * maximum(temperatures)
-    μ_min = epsilon[1] + margin
-    μ_max = epsilon[end] - margin
-    if μ_min >= μ_max
-        error("Energy window too narrow for requested temperatures")
+    # Step 3: μ range — auto-generate from DOS grid, or use caller-supplied grid
+    if isnothing(mur)
+        margin = 9.0 * KB_AU * maximum(temperatures)
+        μ_min = epsilon[1] + margin
+        μ_max = epsilon[end] - margin
+        if μ_min >= μ_max
+            error("Energy window too narrow for requested temperatures")
+        end
+        μ_indices = findall(e -> e > μ_min && e < μ_max, epsilon)
+        μ_range = epsilon[μ_indices]
+    else
+        μ_range = collect(Float64, mur)
     end
-    μ_indices = findall(e -> e > μ_min && e < μ_max, epsilon)
-    μ_range = epsilon[μ_indices]
 
     # Step 4: μ for each T + refined Fermi (T=0)
     Tr = collect(Float64, temperatures)

--- a/src/solve_transport.jl
+++ b/src/solve_transport.jl
@@ -2,7 +2,7 @@
 # Copyright (C) 2026 Hiroharu Sugawara
 # Part of BoltzTraP.jl
 
-#=
+"""
     solve_transport(sampling, interp, sys; kwargs...) -> TransportResult
 
 Method-dispatched entry point for transport calculations on the
@@ -18,9 +18,7 @@ Method overloads:
 The concrete `UniformMesh + FourierInterpolator` method below mirrors the
 existing `run_integrate(::InterpolationResult)` flow so its output is
 bit-equal under default kwargs.
-=#
-
-# Generic fallback for arguments that do not match the abstract-type contract.
+"""
 function solve_transport(sampling, interp, sys; kwargs...)
     sampling isa AbstractBZSampling || throw(
         ArgumentError(

--- a/src/solve_transport.jl
+++ b/src/solve_transport.jl
@@ -61,7 +61,7 @@ end
 
 # Concrete dispatch: UniformMesh + FourierInterpolator
 function solve_transport(
-    ::UniformMesh,
+    sampling::UniformMesh,
     interp::FourierInterpolator,
     sys::TransportSystem;
     temperatures::AbstractVector{<:Real} = [300.0],
@@ -147,6 +147,8 @@ function solve_transport(
 
     result_metadata = Dict{String,Any}(
         "source" => "solve_transport",
+        "sampling" => string(nameof(typeof(sampling))),
+        "interpolator" => replace(string(nameof(typeof(interp))), "Interpolator" => ""),
         "nelect" => nelect,
         "dosweight" => dosweight,
         "spintype" => spintype_str,

--- a/src/solve_transport.jl
+++ b/src/solve_transport.jl
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of BoltzTraP.jl
+
+#=
+    solve_transport(sampling, interp, sys; kwargs...) -> TransportResult
+
+Method-dispatched entry point for transport calculations on the
+`AbstractBZSampling` × `AbstractInterpolator` × `TransportSystem` axes.
+
+Method overloads:
+
+  - `::Any` fallback: throws `ArgumentError` naming the offending argument type
+  - `::AbstractBZSampling, ::AbstractInterpolator, ::TransportSystem`:
+    throws `ErrorException` for a sampling subtype that has no concrete method
+  - concrete pair (e.g. `UniformMesh + FourierInterpolator`): actual computation
+
+The concrete `UniformMesh + FourierInterpolator` method below mirrors the
+existing `run_integrate(::InterpolationResult)` flow so its output is
+bit-equal under default kwargs.
+=#
+
+# Generic fallback for arguments that do not match the abstract-type contract.
+function solve_transport(sampling, interp, sys; kwargs...)
+    sampling isa AbstractBZSampling || throw(
+        ArgumentError(
+            "solve_transport: sampling must be ::AbstractBZSampling, got $(typeof(sampling)).",
+        ),
+    )
+    interp isa AbstractInterpolator || throw(
+        ArgumentError(
+            "solve_transport: interp must be ::AbstractInterpolator, got $(typeof(interp)).",
+        ),
+    )
+    sys isa TransportSystem || throw(
+        ArgumentError(
+            "solve_transport: sys must be ::TransportSystem, got $(typeof(sys)).",
+        ),
+    )
+    throw(
+        ArgumentError(
+            "solve_transport: no concrete method for " *
+            "($(typeof(sampling)), $(typeof(interp)), $(typeof(sys))).",
+        ),
+    )
+end
+
+# Subtype-without-impl fallback for AbstractBZSampling subtypes that do not
+# provide a concrete method.
+function solve_transport(
+    sampling::AbstractBZSampling,
+    interp::AbstractInterpolator,
+    sys::TransportSystem;
+    kwargs...,
+)
+    error(
+        "solve_transport: not implemented for sampling type $(typeof(sampling)). " *
+        "Concrete subtypes of AbstractBZSampling must define their own method.",
+    )
+end
+
+# Concrete dispatch: UniformMesh + FourierInterpolator
+function solve_transport(
+    ::UniformMesh,
+    interp::FourierInterpolator,
+    sys::TransportSystem;
+    temperatures::AbstractVector{<:Real} = [300.0],
+    bins::Int = 0,
+    scissor::Union{Nothing,Real} = nothing,
+    verbose::Bool = false,
+)::TransportResult
+    nelect = sys.nelect
+    dosweight = sys.dosweight
+    fermi_dft = sys.fermi
+
+    # Step 1: bands via FFT (Fourier-specific)
+    eband, vvband = getBTPbands(interp.coeffs, interp.equivalences, interp.lattvec)
+    nbands, npts = size(eband)
+
+    # Step 1.5: optional scissor correction
+    scissor_Ha = nothing
+    if !isnothing(scissor)
+        scissor_Ha = scissor * EV_TO_HA
+        npts_dos_temp = bins > 0 ? bins : 500
+        epsilon_temp, dos_temp, _ = BTPDOS(eband, vvband; npts = npts_dos_temp)
+        eband = apply_scissor(epsilon_temp, dos_temp, nelect, eband, scissor_Ha; dosweight)
+    end
+
+    # Step 2: DOS and transport DOS
+    npts_dos = bins > 0 ? bins : 500
+    epsilon, dos, vvdos = BTPDOS(eband, vvband; npts = npts_dos)
+
+    # Step 3: μ range (auto-generate from DOS grid)
+    margin = 9.0 * KB_AU * maximum(temperatures)
+    μ_min = epsilon[1] + margin
+    μ_max = epsilon[end] - margin
+    if μ_min >= μ_max
+        error("Energy window too narrow for requested temperatures")
+    end
+    μ_indices = findall(e -> e > μ_min && e < μ_max, epsilon)
+    μ_range = epsilon[μ_indices]
+
+    # Step 4: μ for each T + refined Fermi (T=0)
+    Tr = collect(Float64, temperatures)
+    nT = length(Tr)
+    μ0 = zeros(nT)
+    for (iT, T) in enumerate(Tr)
+        μ0[iT] = solve_for_mu(
+            epsilon,
+            dos,
+            nelect,
+            T;
+            dosweight,
+            refine = true,
+            try_center = true,
+        )
+    end
+    fermi_Ha =
+        solve_for_mu(epsilon, dos, nelect, 0.0; dosweight, refine = true, try_center = true)
+
+    # Step 5: Fermi integrals
+    N, L0, L1, L2 = fermi_integrals(epsilon, dos, vvdos, μ_range, Tr; dosweight)
+
+    # Step 6: Onsager coefficients (volume in Å³ matches Python BoltzTraP2)
+    lattvec_ang = sys.lattice * BOHR_TO_ANG
+    vuc = abs(det(lattvec_ang))
+    σ, S, κ = calc_onsager_coefficients(L0, L1, L2, Tr, vuc)
+
+    # Step 7: μ to eV for output
+    μ_range_eV = μ_range .* HA_TO_EV
+
+    # Step 8: result metadata + tensor reshape
+    spintype_str = if sys.spintype isa Unpolarized
+        "Unpolarized"
+    elseif sys.spintype isa Collinear
+        "Collinear"
+    elseif sys.spintype isa NonCollinear
+        "NonCollinear"
+    else
+        "Unknown"
+    end
+
+    result_metadata = Dict{String,Any}(
+        "source" => "solve_transport",
+        "nelect" => nelect,
+        "dosweight" => dosweight,
+        "spintype" => spintype_str,
+        "fermi_Ha" => fermi_Ha,
+        "fermi_eV" => fermi_Ha * HA_TO_EV,
+        "fermi_dft_Ha" => fermi_dft,
+        "fermi_dft_eV" => fermi_dft * HA_TO_EV,
+        "mu0_Ha" => μ0,
+        "mu0_eV" => μ0 .* HA_TO_EV,
+        "vuc_ang3" => vuc,
+        "nbands" => nbands,
+        "npts_fft" => npts,
+        "npts_dos" => npts_dos,
+    )
+    if !isnothing(scissor)
+        result_metadata["scissor_eV"] = scissor
+        result_metadata["scissor_Ha"] = scissor_Ha
+    end
+
+    σ_out = permutedims(σ, (3, 4, 1, 2))
+    S_out = permutedims(S, (3, 4, 1, 2))
+    κ_out = permutedims(κ, (3, 4, 1, 2))
+
+    dos_info = Dict{String,Any}(
+        "epsilon_Ha" => epsilon,
+        "epsilon_eV" => epsilon .* HA_TO_EV,
+        "dos" => dos,
+    )
+
+    return TransportResult(Tr, μ_range_eV, σ_out, S_out, κ_out, dos_info, result_metadata)
+end

--- a/src/workflow.jl
+++ b/src/workflow.jl
@@ -515,152 +515,20 @@ function run_integrate(
     scissor::Union{Nothing,Real} = nothing,
     verbose::Bool = false,
 )
-    # Log received arguments
     @debug "run_integrate called" temperatures output bins scissor verbose
 
-    # Extract metadata
-    # Note: fermi is stored in Ha (atomic units)
-    nelect = get(interp.metadata, "nelect", 0.0)
-    dosweight = get(interp.metadata, "dosweight", 2.0)
-    fermi_dft = get(interp.metadata, "fermi", 0.0)  # in Ha
-    source = get(interp.metadata, "source_file", "unknown")
-    spintype = get(interp.metadata, "spintype", "Unpolarized")  # v0.1 compat
-
-    if nelect == 0.0
-        error("nelect not found in interpolation metadata")
-    end
-
-    verbose && println("  nelect: $nelect")
-    verbose && println("  dosweight: $dosweight")
-    verbose && println("  Fermi (from DFT): $(round(fermi_dft, digits=6)) Ha")
-
-    # 1. Reconstruct bands on FFT grid
-    verbose && println("Reconstructing bands via FFT...")
-    eband, vvband = getBTPbands(interp.coeffs, interp.equivalences, interp.lattvec)
-    nbands, npts = size(eband)
-    verbose && println("  Bands: $nbands, FFT points: $npts")
-    verbose && println(
-        "  Energy range: [$(round(minimum(eband), digits=4)), $(round(maximum(eband), digits=4))] Ha",
+    sys = TransportSystem(interp)
+    fi = FourierInterpolator(
+        interp.coeffs,
+        interp.equivalences,
+        SMatrix{3,3,Float64}(interp.lattvec),
     )
 
-    # 1.5. Apply scissor correction if requested
-    scissor_Ha = nothing
-    if !isnothing(scissor)
-        scissor_Ha = scissor * EV_TO_HA  # Convert eV to Ha
-        verbose && println("Applying scissor correction (target gap: $scissor eV)...")
+    result = solve_transport(UniformMesh(), fi, sys; temperatures, bins, scissor, verbose)
 
-        # Compute temporary DOS to find current gap
-        npts_dos_temp = bins > 0 ? bins : 500
-        epsilon_temp, dos_temp, _ = BTPDOS(eband, vvband; npts = npts_dos_temp)
+    # Restore source provenance from the interpolation metadata.
+    result.metadata["source"] = get(interp.metadata, "source_file", "unknown")
 
-        # Apply scissor to shift conduction bands
-        eband = apply_scissor(epsilon_temp, dos_temp, nelect, eband, scissor_Ha; dosweight)
-        verbose && println("  Scissor applied: target gap = $scissor eV")
-    end
-
-    # 2. Compute DOS and transport DOS
-    npts_dos = bins > 0 ? bins : 500
-    verbose && println("Computing DOS (bins=$npts_dos)...")
-    epsilon, dos, vvdos = BTPDOS(eband, vvband; npts = npts_dos)
-    verbose && println(
-        "  DOS energy range: [$(round(epsilon[1], digits=4)), $(round(epsilon[end], digits=4))] Ha",
-    )
-
-    # 3. Determine μ range (auto-generate from DOS grid)
-    # margin = 9 * kB * T_max (ensures ~1e-4 accuracy at edges)
-    kB_Ha_K = KB_AU
-    margin = 9.0 * kB_Ha_K * maximum(temperatures)
-    μ_min = epsilon[1] + margin
-    μ_max = epsilon[end] - margin
-
-    if μ_min >= μ_max
-        error("Energy window too narrow for requested temperatures")
-    end
-
-    μ_indices = findall(e -> e > μ_min && e < μ_max, epsilon)
-    μ_range = epsilon[μ_indices]
-    verbose && println(
-        "  μ range (auto): $(length(μ_range)) points in [$(round(μ_min, digits=4)), $(round(μ_max, digits=4))] Ha",
-    )
-
-    # 4. Solve for intrinsic chemical potential at each temperature
-    verbose && println("Computing intrinsic μ for each temperature...")
-    Tr = collect(Float64, temperatures)
-    nT = length(Tr)
-    μ0 = zeros(nT)
-    for (iT, T) in enumerate(Tr)
-        μ0[iT] = solve_for_mu(
-            epsilon,
-            dos,
-            nelect,
-            T;
-            dosweight,
-            refine = true,
-            try_center = true,
-        )
-        verbose && println("  T=$(T)K: μ0=$(round(μ0[iT], digits=6)) Ha")
-    end
-
-    # Refined Fermi level (T=0)
-    fermi_Ha =
-        solve_for_mu(epsilon, dos, nelect, 0.0; dosweight, refine = true, try_center = true)
-    verbose && println("  Refined Fermi: $(round(fermi_Ha, digits=6)) Ha")
-
-    # 5. Compute Fermi integrals
-    verbose && println("Computing Fermi integrals...")
-    N, L0, L1, L2 = fermi_integrals(epsilon, dos, vvdos, μ_range, Tr; dosweight)
-    verbose && println("  L0 shape: $(size(L0))")
-
-    # 6. Calculate Onsager coefficients
-    verbose && println("Computing Onsager coefficients...")
-    # Convert lattvec from Bohr to Ångström for volume calculation
-    # This matches Python BoltzTraP2's unit conventions
-    lattvec_ang = interp.lattvec * BOHR_TO_ANG  # BOHR_TO_ANG from units.jl
-    vuc = abs(det(lattvec_ang))  # Unit cell volume in Ų
-    σ, S, κ = calc_onsager_coefficients(L0, L1, L2, Tr, vuc)
-    verbose && println("  σ shape: $(size(σ))")
-
-    # 7. Convert μ_range from Ha to eV for output (HA_TO_EV from units.jl)
-    μ_range_eV = μ_range .* HA_TO_EV
-
-    # 8. Create result
-    result_metadata = Dict{String,Any}(
-        "source" => source,
-        "nelect" => nelect,
-        "dosweight" => dosweight,
-        "spintype" => spintype,
-        "fermi_Ha" => fermi_Ha,
-        "fermi_eV" => fermi_Ha * HA_TO_EV,
-        "fermi_dft_Ha" => fermi_dft,
-        "fermi_dft_eV" => fermi_dft * HA_TO_EV,
-        "mu0_Ha" => μ0,
-        "mu0_eV" => μ0 .* HA_TO_EV,
-        "vuc_ang3" => vuc,
-        "nbands" => nbands,
-        "npts_fft" => npts,
-        "npts_dos" => npts_dos,
-    )
-    # Add scissor info if applied
-    if !isnothing(scissor)
-        result_metadata["scissor_eV"] = scissor
-        result_metadata["scissor_Ha"] = scissor_Ha
-    end
-
-    # Reshape tensors to (3, 3, nT, nμ) for TransportResult
-    nμ = length(μ_range)
-    σ_out = permutedims(σ, (3, 4, 1, 2))  # (nT, nμ, 3, 3) -> (3, 3, nT, nμ)
-    S_out = permutedims(S, (3, 4, 1, 2))
-    κ_out = permutedims(κ, (3, 4, 1, 2))
-
-    dos_info = Dict{String,Any}(
-        "epsilon_Ha" => epsilon,
-        "epsilon_eV" => epsilon .* HA_TO_EV,
-        "dos" => dos,
-    )
-
-    result = TransportResult(Tr, μ_range_eV, σ_out, S_out, κ_out, dos_info, result_metadata)
-
-    # 9. Save if output specified
     if !isnothing(output)
         verbose && println("Saving to $output...")
         save_integrate(output, result)
@@ -682,129 +550,18 @@ function run_integrate(
 )
     @debug "run_integrate(interp, mur) called" temperatures output bins scissor verbose
 
-    # Extract metadata
-    nelect = get(interp.metadata, "nelect", 0.0)
-    dosweight = get(interp.metadata, "dosweight", 2.0)
-    fermi_dft = get(interp.metadata, "fermi", 0.0)
-    source = get(interp.metadata, "source_file", "unknown")
-    spintype = get(interp.metadata, "spintype", "Unpolarized")  # v0.1 compat
-
-    if nelect == 0.0
-        error("nelect not found in interpolation metadata")
-    end
-
-    verbose && println("  nelect: $nelect")
-    verbose && println("  dosweight: $dosweight")
-    verbose && println("  Fermi (from DFT): $(round(fermi_dft, digits=6)) Ha")
-
-    # 1. Reconstruct bands on FFT grid
-    verbose && println("Reconstructing bands via FFT...")
-    eband, vvband = getBTPbands(interp.coeffs, interp.equivalences, interp.lattvec)
-    nbands, npts = size(eband)
-    verbose && println("  Bands: $nbands, FFT points: $npts")
-
-    # 1.5. Apply scissor correction if requested
-    scissor_Ha = nothing
-    if !isnothing(scissor)
-        scissor_Ha = scissor * EV_TO_HA  # Convert eV to Ha
-        verbose && println("Applying scissor correction (target gap: $scissor eV)...")
-
-        # Compute temporary DOS to find current gap
-        npts_dos_temp = bins > 0 ? bins : 500
-        epsilon_temp, dos_temp, _ = BTPDOS(eband, vvband; npts = npts_dos_temp)
-
-        # Apply scissor to shift conduction bands
-        eband = apply_scissor(epsilon_temp, dos_temp, nelect, eband, scissor_Ha; dosweight)
-        verbose && println("  Scissor applied: target gap = $scissor eV")
-    end
-
-    # 2. Compute DOS and transport DOS
-    npts_dos = bins > 0 ? bins : 500
-    verbose && println("Computing DOS (bins=$npts_dos)...")
-    epsilon, dos, vvdos = BTPDOS(eband, vvband; npts = npts_dos)
-
-    # 3. Use provided μ range (same as Python BoltzTraP2 `mur` argument)
-    μ_range = collect(Float64, mur)
-    verbose && println(
-        "  μ range (provided): $(length(μ_range)) points in [$(round(minimum(μ_range), digits=4)), $(round(maximum(μ_range), digits=4))] Ha",
+    sys = TransportSystem(interp)
+    fi = FourierInterpolator(
+        interp.coeffs,
+        interp.equivalences,
+        SMatrix{3,3,Float64}(interp.lattvec),
     )
 
-    # 4. Solve for intrinsic chemical potential at each temperature
-    verbose && println("Computing intrinsic μ for each temperature...")
-    Tr = collect(Float64, temperatures)
-    nT = length(Tr)
-    μ0 = zeros(nT)
-    for (iT, T) in enumerate(Tr)
-        μ0[iT] = solve_for_mu(
-            epsilon,
-            dos,
-            nelect,
-            T;
-            dosweight,
-            refine = true,
-            try_center = true,
-        )
-        verbose && println("  T=$(T)K: μ0=$(round(μ0[iT], digits=6)) Ha")
-    end
+    result =
+        solve_transport(UniformMesh(), fi, sys; temperatures, mur, bins, scissor, verbose)
 
-    # Refined Fermi level (T=0)
-    fermi_Ha =
-        solve_for_mu(epsilon, dos, nelect, 0.0; dosweight, refine = true, try_center = true)
-    verbose && println("  Refined Fermi: $(round(fermi_Ha, digits=6)) Ha")
+    result.metadata["source"] = get(interp.metadata, "source_file", "unknown")
 
-    # 5. Compute Fermi integrals
-    verbose && println("Computing Fermi integrals...")
-    N, L0, L1, L2 = fermi_integrals(epsilon, dos, vvdos, μ_range, Tr; dosweight)
-
-    # 6. Calculate Onsager coefficients
-    verbose && println("Computing Onsager coefficients...")
-    # Convert lattvec from Bohr to Ångström for volume calculation
-    # This matches Python BoltzTraP2's unit conventions
-    lattvec_ang = interp.lattvec * BOHR_TO_ANG  # BOHR_TO_ANG from units.jl
-    vuc = abs(det(lattvec_ang))  # Unit cell volume in Ų
-    σ, S, κ = calc_onsager_coefficients(L0, L1, L2, Tr, vuc)
-
-    # 7. Convert μ_range from Ha to eV for output (HA_TO_EV from units.jl)
-    μ_range_eV = μ_range .* HA_TO_EV
-
-    # 8. Create result
-    result_metadata = Dict{String,Any}(
-        "source" => source,
-        "nelect" => nelect,
-        "dosweight" => dosweight,
-        "spintype" => spintype,
-        "fermi_Ha" => fermi_Ha,
-        "fermi_eV" => fermi_Ha * HA_TO_EV,
-        "fermi_dft_Ha" => fermi_dft,
-        "fermi_dft_eV" => fermi_dft * HA_TO_EV,
-        "mu0_Ha" => μ0,
-        "mu0_eV" => μ0 .* HA_TO_EV,
-        "vuc_ang3" => vuc,
-        "nbands" => nbands,
-        "npts_fft" => npts,
-        "npts_dos" => npts_dos,
-    )
-    # Add scissor info if applied
-    if !isnothing(scissor)
-        result_metadata["scissor_eV"] = scissor
-        result_metadata["scissor_Ha"] = scissor_Ha
-    end
-
-    # Reshape tensors to (3, 3, nT, nμ)
-    nμ = length(μ_range)
-    σ_out = permutedims(σ, (3, 4, 1, 2))
-    S_out = permutedims(S, (3, 4, 1, 2))
-    κ_out = permutedims(κ, (3, 4, 1, 2))
-
-    dos_info = Dict{String,Any}(
-        "epsilon_Ha" => epsilon,
-        "epsilon_eV" => epsilon .* HA_TO_EV,
-        "dos" => dos,
-    )
-
-    result = TransportResult(Tr, μ_range_eV, σ_out, S_out, κ_out, dos_info, result_metadata)
-
-    # 9. Save if output specified
     if !isnothing(output)
         verbose && println("Saving to $output...")
         save_integrate(output, result)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -93,6 +93,7 @@ end
     include("test_spintypes.jl")
     include("test_banddata.jl")
     include("test_dftdata_integration.jl")
+    include("test_sampling.jl")
     include("test_plottypes.jl")
     include("test_publication.jl")
 

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -46,3 +46,60 @@ struct _DummySubtypeInterp <: BoltzTraP.AbstractInterpolator end
         )
     end
 end
+
+@testset "TransportSystem" begin
+    # Synthetic InterpolationResult helpers (avoid heavy run_interpolate path)
+    function _synth_interp(;
+        fermi::Float64 = 0.5,
+        nelect::Float64 = 8.0,
+        dosweight::Float64 = 2.0,
+        spintype::String = "Unpolarized",
+    )
+        coeffs = ComplexF64[1.0+0im 2.0+0im; 3.0+0im 4.0+0im]
+        equivs = [reshape([0, 0, 0], 1, 3), reshape([1, 0, 0], 1, 3)]
+        lattvec = 5.0 * Matrix{Float64}(LinearAlgebra.I, 3, 3)
+        metadata = Dict{String,Any}(
+            "fermi" => fermi,
+            "nelect" => nelect,
+            "dosweight" => dosweight,
+            "spintype" => spintype,
+        )
+        return BoltzTraP.InterpolationResult(coeffs, equivs, lattvec, nothing, metadata)
+    end
+
+    @testset "construction from InterpolationResult (non-magnetic Si-like)" begin
+        ir = _synth_interp(;
+            fermi = 0.5,
+            nelect = 8.0,
+            dosweight = 2.0,
+            spintype = "Unpolarized",
+        )
+        sys = BoltzTraP.TransportSystem(ir)
+
+        @test sys.lattice ≈ ir.lattvec
+        @test sys.fermi == 0.5
+        @test sys.nelect == 8.0
+        @test sys.dosweight == 2.0
+        @test sys.spintype isa Unpolarized
+    end
+
+    @testset "construction (collinear magnetic Fe-like)" begin
+        ir = _synth_interp(;
+            fermi = 0.3,
+            nelect = 26.0,
+            dosweight = 1.0,
+            spintype = "Collinear",
+        )
+        sys = BoltzTraP.TransportSystem(ir)
+
+        @test sys.fermi == 0.3
+        @test sys.nelect == 26.0
+        @test sys.dosweight == 1.0
+        @test sys.spintype isa Collinear
+    end
+
+    @testset "unknown spintype throws" begin
+        ir = _synth_interp(; spintype = "AlienSpin")
+        @test_throws ErrorException BoltzTraP.TransportSystem(ir)
+    end
+end

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Copyright (C) 2026 Hiroharu Sugawara
+# Part of BoltzTraP.jl
+
+# Helper subtype for abstract-type fallback test (issue #54).
+# Defined at top level because Julia struct declarations cannot be inside
+# function/begin/let blocks.
+struct _DummySubtypeInterp <: BoltzTraP.AbstractInterpolator end
+
+@testset "AbstractBZSampling and interface hygiene" begin
+    @testset "type hierarchy" begin
+        @test isa(UniformMesh(), BoltzTraP.AbstractBZSampling)
+        @test isa(UniformMesh((4, 4, 4)), BoltzTraP.AbstractBZSampling)
+    end
+
+    @testset "UniformMesh constructors" begin
+        # Default constructor: nk unspecified (interpolator decides at runtime)
+        @test UniformMesh().nk === nothing
+        # Explicit nk: user-specified mesh
+        @test UniformMesh((4, 4, 4)).nk == (4, 4, 4)
+        @test UniformMesh((8, 8, 8)).nk == (8, 8, 8)
+    end
+
+    @testset "AbstractInterpolator abstract-type fallback (subtype without impl, #54)" begin
+        # interpolate_bands: dispatch falls to abstract-type ::AbstractInterpolator method,
+        # which throws ErrorException with a message naming the actual subtype
+        # (rather than the misleading "expects a concrete subtype" from ::Any fallback).
+        @test_throws ErrorException BoltzTraP.interpolate_bands(
+            _DummySubtypeInterp(),
+            zeros(0, 3),
+        )
+
+        # interpolate_velocities: same abstract-type behavior
+        @test_throws ErrorException BoltzTraP.interpolate_velocities(
+            _DummySubtypeInterp(),
+            zeros(0, 3),
+        )
+
+        # interpolate(::AbstractInterpolator, kpoints) at src/interpolation.jl:64
+        # is the existing default delegate that calls interpolate_bands and
+        # interpolate_velocities. For _DummySubtypeInterp it cascades through the
+        # new abstract-type fallback and throws ErrorException.
+        @test_throws ErrorException BoltzTraP.interpolate(
+            _DummySubtypeInterp(),
+            zeros(0, 3),
+        )
+    end
+end

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -187,3 +187,40 @@ struct _DummyBZSampling <: BoltzTraP.AbstractBZSampling end
         end
     end
 end
+
+@testset "run_integrate (backward-compat wrapper)" begin
+    @testset "auto μ grid wrapper preserves source metadata" begin
+        datadir = joinpath(@__DIR__, "..", "benchmarks", "data", "Si.vasp")
+        if isdir(datadir) && isfile(joinpath(datadir, "vasprun.xml"))
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            result = BoltzTraP.run_integrate(ir; temperatures = [300.0])
+
+            @test result isa TransportResult
+            @test size(result.sigma, 3) == 1
+            @test !any(isnan, result.sigma)
+            # source must come from IR metadata (wrapper restores), not the
+            # solve_transport delegate's hardcoded "solve_transport".
+            @test result.metadata["source"] != "solve_transport"
+            @test haskey(result.metadata, "fermi_Ha")
+            @test haskey(result.metadata, "vuc_ang3")
+        else
+            @warn "Skipping run_integrate auto-μ wrapper test: data not found at $datadir"
+        end
+    end
+
+    @testset "explicit μ grid wrapper (positional mur)" begin
+        datadir = joinpath(@__DIR__, "..", "benchmarks", "data", "Si.vasp")
+        if isdir(datadir) && isfile(joinpath(datadir, "vasprun.xml"))
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            mur_test = collect(0.0:0.05:0.5)
+            result = BoltzTraP.run_integrate(ir, mur_test; temperatures = [300.0])
+
+            @test result isa TransportResult
+            @test length(result.mu_values) == length(mur_test)
+            @test !any(isnan, result.sigma)
+            @test result.metadata["source"] != "solve_transport"
+        else
+            @warn "Skipping run_integrate explicit-μ wrapper test: data not found at $datadir"
+        end
+    end
+end

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -103,3 +103,87 @@ end
         @test_throws ErrorException BoltzTraP.TransportSystem(ir)
     end
 end
+
+# Helper: dummy AbstractBZSampling subtype for abstract-type fallback test
+struct _DummyBZSampling <: BoltzTraP.AbstractBZSampling end
+
+@testset "solve_transport dispatch" begin
+    @testset "rejects wrong argument types (::Any fallback)" begin
+        # Build minimal valid interp + sys for the "other two args correct" cases
+        ir = let
+            coeffs = ComplexF64[1.0+0im 2.0+0im; 3.0+0im 4.0+0im]
+            equivs = [reshape([0, 0, 0], 1, 3), reshape([1, 0, 0], 1, 3)]
+            lattvec = 5.0 * Matrix{Float64}(LinearAlgebra.I, 3, 3)
+            metadata = Dict{String,Any}(
+                "fermi" => 0.5,
+                "nelect" => 8.0,
+                "dosweight" => 2.0,
+                "spintype" => "Unpolarized",
+            )
+            BoltzTraP.InterpolationResult(coeffs, equivs, lattvec, nothing, metadata)
+        end
+        fi = BoltzTraP.FourierInterpolator(
+            ir.coeffs,
+            ir.equivalences,
+            SMatrix{3,3,Float64}(ir.lattvec),
+        )
+        sys = BoltzTraP.TransportSystem(ir)
+
+        # Wrong sampling type
+        @test_throws ArgumentError solve_transport("not_sampling", fi, sys)
+        # Wrong interpolator type
+        @test_throws ArgumentError solve_transport(UniformMesh(), "not_interp", sys)
+        # Wrong sys type
+        @test_throws ArgumentError solve_transport(UniformMesh(), fi, "not_sys")
+    end
+
+    @testset "rejects subtype without concrete method (::AbstractBZSampling fallback)" begin
+        ir = let
+            coeffs = ComplexF64[1.0+0im 2.0+0im; 3.0+0im 4.0+0im]
+            equivs = [reshape([0, 0, 0], 1, 3), reshape([1, 0, 0], 1, 3)]
+            lattvec = 5.0 * Matrix{Float64}(LinearAlgebra.I, 3, 3)
+            metadata = Dict{String,Any}(
+                "fermi" => 0.5,
+                "nelect" => 8.0,
+                "dosweight" => 2.0,
+                "spintype" => "Unpolarized",
+            )
+            BoltzTraP.InterpolationResult(coeffs, equivs, lattvec, nothing, metadata)
+        end
+        fi = BoltzTraP.FourierInterpolator(
+            ir.coeffs,
+            ir.equivalences,
+            SMatrix{3,3,Float64}(ir.lattvec),
+        )
+        sys = BoltzTraP.TransportSystem(ir)
+
+        # _DummyBZSampling has no concrete solve_transport method, falls to
+        # the abstract-type fallback that throws ErrorException.
+        @test_throws ErrorException solve_transport(_DummyBZSampling(), fi, sys)
+    end
+
+    @testset "concrete UniformMesh + FourierInterpolator on Si VASP" begin
+        datadir = joinpath(@__DIR__, "..", "benchmarks", "data", "Si.vasp")
+        if isdir(datadir) && isfile(joinpath(datadir, "vasprun.xml"))
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            sys = BoltzTraP.TransportSystem(ir)
+            fi = BoltzTraP.FourierInterpolator(
+                ir.coeffs,
+                ir.equivalences,
+                SMatrix{3,3,Float64}(ir.lattvec),
+            )
+            result = solve_transport(UniformMesh(), fi, sys; temperatures = [300.0])
+
+            @test result isa TransportResult
+            @test size(result.sigma, 1) == 3
+            @test size(result.sigma, 2) == 3
+            @test size(result.sigma, 3) == 1   # 1 temperature
+            @test size(result.sigma, 4) == length(result.mu_values)
+            @test !any(isnan, result.sigma)
+            @test !any(isnan, result.seebeck)
+            @test !any(isnan, result.kappa)
+        else
+            @warn "Skipping solve_transport Si VASP integration test: data not found at $datadir"
+        end
+    end
+end

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -224,3 +224,65 @@ end
         end
     end
 end
+
+@testset "provenance metadata" begin
+    datadir = joinpath(@__DIR__, "..", "benchmarks", "data", "Si.vasp")
+    have_data = isdir(datadir) && isfile(joinpath(datadir, "vasprun.xml"))
+
+    @testset "solve_transport stamps sampling/interpolator + preserves legacy keys" begin
+        if have_data
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            sys = BoltzTraP.TransportSystem(ir)
+            fi = BoltzTraP.FourierInterpolator(
+                ir.coeffs,
+                ir.equivalences,
+                SMatrix{3,3,Float64}(ir.lattvec),
+            )
+            result = solve_transport(UniformMesh(), fi, sys; temperatures = [300.0])
+
+            # New provenance keys.
+            @test result.metadata["sampling"] == "UniformMesh"
+            @test result.metadata["interpolator"] == "Fourier"
+
+            # Legacy metadata keys must remain (regression: stamping is additive).
+            for key in ("nelect", "dosweight", "fermi_Ha", "vuc_ang3", "nbands", "npts_dos")
+                @test haskey(result.metadata, key)
+            end
+        else
+            @warn "Skipping provenance metadata (solve_transport): data not found at $datadir"
+        end
+    end
+
+    @testset "run_integrate wrapper preserves provenance + source override" begin
+        if have_data
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            result = BoltzTraP.run_integrate(ir; temperatures = [300.0])
+
+            # Wrapper passes through new keys from solve_transport.
+            @test result.metadata["sampling"] == "UniformMesh"
+            @test result.metadata["interpolator"] == "Fourier"
+
+            # Wrapper's source override does not clobber the provenance keys.
+            @test result.metadata["source"] != "solve_transport"
+        else
+            @warn "Skipping provenance metadata (wrapper): data not found at $datadir"
+        end
+    end
+
+    @testset "JLD2 round-trip preserves provenance keys" begin
+        if have_data
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            result = BoltzTraP.run_integrate(ir; temperatures = [300.0])
+
+            mktempdir() do dir
+                path = joinpath(dir, "provenance_roundtrip.jld2")
+                save_integrate(path, result)
+                loaded = load_integrate(path)
+                @test loaded.metadata["sampling"] == "UniformMesh"
+                @test loaded.metadata["interpolator"] == "Fourier"
+            end
+        else
+            @warn "Skipping provenance metadata (JLD2 round-trip): data not found at $datadir"
+        end
+    end
+end


### PR DESCRIPTION
Refs #53, Closes #54, Closes #55

## Test plan
- [x] Pkg.test green (5955 → 6000 passed, +45 new tests)
- [x] AbstractBZSampling + UniformMesh + TransportSystem types compile, dispatch surface working
- [x] solve_transport(UniformMesh, FourierInterpolator, TransportSystem) reproduces v0.3.2 run_integrate output bit-equal on Si and PbTe golden files
- [x] run_integrate(::InterpolationResult) wrapper preserves legacy API: existing reference tests pass (Fe collinear, calc_N, bandlib, fite) + v0.3.2 Si/PbTe golden bit-equal via legacy API path
- [x] TransportResult.metadata stamps "sampling" / "interpolator" provenance keys, preserved through JLD2 round-trip
- [x] BT.jl ↔ Python BoltzTraP2 σ/S/κ 5+ digit agreement maintained on Si (T = [200, 300, 400] K)
- [x] Format.yml green (no drift), docs build clean (new "Architecture" page)