### PR TITLE
fix: use pinv in fitde3D for rank-deficient Hmat (Fourier)

### DIFF
--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -347,10 +347,16 @@ function fitde3D(kpoints, energies, equivalences, lattvec)
     Hmat = real(phaseR[:, 2:end] * conj(weighted_phaseR)')
 
     # Solve least squares: Hmat @ rlambda = De.T
-    # Python: rlambda = lstsq(Hmat, De)[0]
+    # Python: rlambda = sp.linalg.lstsq(Hmat, De)[0]  (SVD, rank-deficient OK)
     # De.T in Python is (nk-1, nbands), our De is (nbands, nk-1)
-    # So we need De' for the solve
-    rlambda = Hmat \ De'  # (nk-1, nbands)
+    # So we need De' for the solve.
+    # Julia's `\` on a square matrix uses an LU factorization, which raises
+    # SingularException for a rank-deficient Hmat (high-symmetry small cells
+    # where the source k-mesh is sparse relative to the equivalence stars).
+    # `pinv` (Moore-Penrose, SVD-based) reproduces scipy.linalg.lstsq's
+    # minimum-norm least-squares solution and is identical to `\` for the
+    # full-rank case up to round-off.
+    rlambda = pinv(Hmat) * De'  # (nk-1, nbands)
 
     # Recover coefficients
     # Python: coeffs = rhoi * (rlambda.T @ phaseR)

--- a/test/test_dftdata_integration.jl
+++ b/test/test_dftdata_integration.jl
@@ -83,9 +83,13 @@ using BoltzTraP
         @test hasmethod(run_interpolate, Tuple{DFTData{1}})
     end
 
-    @testset "DFTData and NamedTuple produce same error with insufficient data" begin
-        # With insufficient k-points, both should throw the same error
-        # This verifies DFTData method delegates correctly to NamedTuple method
+    @testset "DFTData and NamedTuple produce same result with sparse data" begin
+        # With a sparse k-mesh the regularized normal matrix in fitde3D is
+        # rank-deficient. Since the pinv-based solve (issue #67 fix) returns
+        # the minimum-norm least-squares solution instead of raising
+        # SingularException, neither path throws. This still verifies the
+        # DFTData method delegates correctly to the NamedTuple method, i.e.
+        # both paths produce identical coefficients.
         data_dft = DFTData(
             lattice = lattice,
             positions = positions,
@@ -110,8 +114,13 @@ using BoltzTraP
             nelect = nelect,
         )
 
-        # Both should throw SingularException (insufficient k-points for fitting)
-        @test_throws LinearAlgebra.SingularException run_interpolate(data_dft; kpoints = 10)
-        @test_throws LinearAlgebra.SingularException run_interpolate(data_nt; kpoints = 10)
+        # Neither path throws (pinv handles the rank-deficient Hmat). Both
+        # must return identical coefficients, confirming the DFTData method
+        # delegates to the NamedTuple method.
+        res_dft = run_interpolate(data_dft; kpoints = 10)
+        res_nt = run_interpolate(data_nt; kpoints = 10)
+        @test res_dft.coeffs == res_nt.coeffs
+        @test !any(isnan, res_dft.coeffs)
+        @test !any(isinf, res_dft.coeffs)
     end
 end

--- a/test/test_fite.jl
+++ b/test/test_fite.jl
@@ -53,6 +53,46 @@ using BoltzTraP: FourierInterpolator, interpolate, interpolate_bands, interpolat
         @test !any(isinf, coeffs)
     end
 
+    @testset "fitde3D rank-deficient Hmat (issue #67 regression)" begin
+        # Reproduce the issue #67 failure mode: when the regularized normal
+        # matrix Hmat is rank-deficient (source k-mesh sparse relative to the
+        # equivalence stars, as for high-symmetry small primitive cells),
+        # the old `Hmat \ De'` (LU) raised SingularException. The pinv fix
+        # (scipy.linalg.lstsq-equivalent SVD minimum-norm solution) must
+        # return finite coefficients without raising.
+        #
+        # Construction: reuse the validated Si fixture but truncate the
+        # equivalence-star list so that neq < nk. Then Hmat is (nk-1, nk-1)
+        # with rank <= neq-1 < nk-1, i.e. exactly singular -> the pre-fix
+        # code path would have thrown.
+        si_file = joinpath(dirname(TEST_DIR), "reftest", "data", "si_interpolation.npz")
+        if !isfile(si_file)
+            @test_skip "Si interpolation data not available"
+            return
+        end
+
+        si_data = npzread(si_file)
+        kpoints = si_data["kpoints"]
+        ebands = si_data["ebands"]
+        lattvec = si_data["lattvec"]
+        n_eq = si_data["n_equivalences"]
+        equivalences_full = [si_data["equiv_$i"] for i = 0:(n_eq-1)]
+
+        nk = size(kpoints, 1)
+        # Truncate to make neq < nk (need neq >= 3 so the rhoi reference
+        # star R[2] exists; cap at the available count).
+        neq_trunc = clamp(nk ÷ 4, 3, n_eq)
+        @test neq_trunc < nk          # ensures Hmat is rank-deficient
+        equivalences_rd = equivalences_full[1:neq_trunc]
+
+        # Regression: must NOT raise (previously SingularException).
+        coeffs = BoltzTraP.fitde3D(kpoints, ebands, equivalences_rd, lattvec)
+
+        @test size(coeffs) == (size(ebands, 1), neq_trunc)
+        @test !any(isnan, coeffs)
+        @test !any(isinf, coeffs)
+    end
+
     @testset "getBands reconstruct" begin
         # getBands should be able to reconstruct the original bands
         si_file = joinpath(dirname(TEST_DIR), "reftest", "data", "si_interpolation.npz")
@@ -254,9 +294,13 @@ using BoltzTraP: FourierInterpolator, interpolate, interpolate_bands, interpolat
         # Shapes should match
         @test size(coeffs_julia) == size(coeffs_ref)
 
-        # Coefficients should be very close (same algorithm)
+        # Coefficients should be very close. The pinv (SVD) solve in fitde3D
+        # (issue #67 fix) differs from the previous LU `\` solve by SVD
+        # round-off on well-conditioned matrices (~2e-10 here); both are
+        # equally valid least-squares solutions. Tolerance loosened from
+        # 1e-10 to 1e-9 to accommodate the LU -> SVD round-off.
         max_diff = maximum(abs.(coeffs_julia - coeffs_ref))
-        @test max_diff < 1e-10
+        @test max_diff < 1e-9
     end
 
     @testset "getBTPbands FFT reconstruction" begin


### PR DESCRIPTION
Replace `Hmat \ De'` (LU) with `pinv(Hmat) * De'` (SVD) in fitde3D, reproducing Python BoltzTraP2's `scipy.linalg.lstsq` minimum-norm solution; equivalent to `\` for the full-rank case up to round-off.

Closes #67