### PR TITLE
Prepare v0.3.4 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "BoltzTraP"
 uuid = "cbda18ea-c181-4d25-a1c9-354b8a2900c6"
 license = "GPL-3.0-or-later"
 authors = ["Hiroharu Sugawara <hsugawa@gmail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 CodecXz = "ba30903b-d9e8-5048-a5ec-d1f5b0d4b47b"


### PR DESCRIPTION
v0.3.4 release: version bump only. The fitde3D pinv fix for
rank-deficient `Hmat` (#67) is already in main via #68.