### PR TITLE
docs: update DOI to v0.3.4

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,9 +8,9 @@ authors:
     email: hsugawa@gmail.com
 repository-code: "https://github.com/hsugawa8651/BoltzTraP.jl"
 license: GPL-3.0-or-later
-version: 0.3.3
-date-released: 2026-05-03
-doi: "10.5281/zenodo.19996150"
+version: 0.3.4
+date-released: 2026-05-17
+doi: "10.5281/zenodo.20255943"
 keywords:
   - band structure
   - interpolation

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Bug reports and feature requests are welcome via [GitHub Issues](https://github.
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.3) [Computer software]. https://doi.org/10.5281/zenodo.19996150
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.4) [Computer software]. https://doi.org/10.5281/zenodo.20255943
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -102,7 +102,7 @@ Key differences:
 If you use BoltzTraP.jl in your research, please cite both:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.3) [Computer software]. [doi:10.5281/zenodo.19996150](https://doi.org/10.5281/zenodo.19996150)
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.3.4) [Computer software]. [doi:10.5281/zenodo.20255943](https://doi.org/10.5281/zenodo.20255943)
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)


### PR DESCRIPTION
Post-release DOI update for v0.3.4. Citation snippets (README, CITATION.cff, docs/src/index.md) -> Version DOI 10.5281/zenodo.20255943. README badge (Concept DOI 10.5281/zenodo.18253185) unchanged per policy.