### PR TITLE
Retitle the Wannier/DFTK docs pages and lift them to top level

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,8 +20,6 @@ makedocs(
         "Guide" => [
             "CLI Workflow" => "cli.md",
             "API Workflow" => "workflow.md",
-            "DFTK.jl Integration" => "dftk.md",
-            "Wannier.jl Integration" => "wannier.md",
             "Interpolation" => "interpolate.md",
             "Integration" => "integrate.md",
             "Utilities" => "utilities.md",
@@ -33,6 +31,8 @@ makedocs(
         ],
         "Architecture" => "architecture.md",
         "Magnetic Materials" => "magnetic.md",
+        "DFTK pipeline" => "dftk.md",
+        "Wannier path" => "wannier.md",
         "Validation" => "validation.md",
         "Benchmarks" => "benchmarks.md",
         "Reference Tests" => "reftest.md",

--- a/docs/src/dftk.md
+++ b/docs/src/dftk.md
@@ -1,4 +1,4 @@
-# DFTK.jl Integration
+# DFTK pipeline
 
 This is a variant of the [API Workflow](@ref) that enables a complete Julia-only workflow from first-principles electronic structure calculations to Boltzmann transport coefficients.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,7 +53,7 @@ For detailed CLI usage, see [CLI Workflow](@ref). For Julia API, see [API Workfl
 
 - **Julia API**: Programmatic workflow with `run_interpolate()` and `run_integrate()` functions
 - **[DFTK.jl](https://dftk.org/) integration**: Direct coupling with Julia-native DFT package via `load_dftk()`
-- **[Wannier.jl](https://github.com/qiaojunfeng/Wannier.jl) integration**: Optional Wannier-basis interpolation path (v0.4+); see [Wannier.jl Integration](@ref)
+- **[Wannier.jl](https://github.com/qiaojunfeng/Wannier.jl) integration**: Optional Wannier-basis interpolation path (v0.4+); see [Wannier path](@ref)
 - **JLD2 format**: Fast HDF5-based native Julia format for result files
 
 ## Installation

--- a/docs/src/input_formats.md
+++ b/docs/src/input_formats.md
@@ -204,7 +204,7 @@ Si.abinit/
 
 ## [DFTK.jl](@id input-dftk)
 
-See [DFTK.jl Integration](@ref) for detailed documentation.
+See [DFTK pipeline](@ref) for detailed documentation.
 
 ---
 

--- a/docs/src/wannier.md
+++ b/docs/src/wannier.md
@@ -1,4 +1,4 @@
-# Wannier.jl Integration
+# Wannier path
 
 BoltzTraP.jl supports band and velocity interpolation through a Wannier
 basis via the [Wannier.jl](https://github.com/qiaojunfeng/Wannier.jl)

--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -133,7 +133,7 @@ transport = run_integrate(interp; temperatures=[300.0])
 
 ## DFTK Workflow
 
-See [DFTK.jl Integration](@ref) for detailed documentation.
+See [DFTK pipeline](@ref) for detailed documentation.
 
 ---
 


### PR DESCRIPTION
Closes #74
Closes #75

## Test plan
- [ ] Docs build clean; no unresolved `@ref` to the old "Integration" titles
- [ ] Sidebar: Magnetic Materials / DFTK pipeline / Wannier path are top-level in that order
- [ ] `wannier.md` H1 = "Wannier path"; `dftk.md` H1 = "DFTK pipeline"
