### PR TITLE
Fix the corrupted BandData docstring example

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -154,10 +154,11 @@ data = BandData(;
     kpoints = K,
     ebands = E,
     fermi = 0.2,
-    nelect = 8.0,#=
-    magmom = [1.0, -1.0],    BandData(; lattice, positions, species, kpoints, ebands, fermi, nelect,
-)               magmom=nothing) -> BandData{ST}
+    nelect = 8.0,
+    magmom = [1.0, -1.0],
+)
 ```
+
 Construct BandData with SpinType inferred from magmom.
 See also: [`SpinType`](@ref), [`Unpolarized`](@ref), [`Collinear`](@ref), [`NonCollinear`](@ref)
 """


### PR DESCRIPTION
Refs #53

## Test plan
- [ ] CI Format passes — `src/types.jl` now parses and is format-clean (it was previously skipped by JuliaFormatter due to a parse error in the BandData docstring example, so the file was never checked)
- [ ] CI matrix (4 core + 4 ext) PASS, no warning-count regression
- [ ] Docs build renders the BandData docstring
