### PR TITLE
Add a documented CoSb₃ baseline for the Fourier transport path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ reftest/data/*
 !reftest/data/geometries/
 !reftest/data/si_wannier_transport.jld2
 !reftest/data/cosb3_wannier_baseline.toml
+!reftest/data/cosb3_fourier_baseline.toml
 
 # Paper build artifacts
 paper/paper.pdf

--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -105,6 +105,35 @@ reftest/
 | 7 | `generate_synthetic_*.py` | Synthetic low-symmetry test data |
 | - | `compare.jl` | Julia comparison against reference data |
 
+### CoSb₃ Fourier documented baseline (manual)
+
+The Fourier path was exercised on CoSb₃ (conventional cubic skutterudite,
+space group 204, a = 17.080296 Bohr ≈ 9.04 Å; lattice data shipped at
+`reftest/data/geometries/cosb3.jl`) using a DFTK SCF result followed by a
+non-self-consistent band evaluation (`compute_bands`) on a 16×16×16 mesh,
+then BoltzTraP.jl's Fourier (star-function) interpolation and transport.
+The baseline records σ_xx × τ at T = 300 K (τ = 10 fs) for 17
+chemical-potential offsets μ_eff in eV relative to the intrinsic Fermi
+level; the full data is shipped at `reftest/data/cosb3_fourier_baseline.toml`.
+
+This is a manual documented baseline — a frozen BoltzTraP.jl
+self-consistency record, not an automated CI regression test (unlike the
+Si Fourier and Si Wannier reftests, which run in CI) and not a
+Pizzi-conformance test. It exists so future lattice or interpolation
+regressions in the Fourier path are detectable by hand. The two anchor
+points are:
+
+| μ_eff | σ_xx × τ | reference |
+|------:|---------:|:---|
+| (eV) | (×10⁶ S/m) | (×10⁶ S/m) |
+| **−1.25** | **0.9779** | ≈ 1.0 (Pizzi 2014 valence anchor, ~3% agreement) |
+| **0.00** | **0.0394** | ≈ 0 (mid-gap, expected) |
+
+The DFTK SCF checkpoint used to produce these numbers (≈ 295 MB) is not
+shipped with the repository; the values in
+`reftest/data/cosb3_fourier_baseline.toml` stand on their own as the
+documented baseline.
+
 ## Verify It Yourself
 
 You can reproduce the validation using the tools provided in the [`reftest/`](https://github.com/hsugawa8651/BoltzTraP.jl/tree/main/reftest) and [`validation/`](https://github.com/hsugawa8651/BoltzTraP.jl/tree/main/validation) directories.

--- a/reftest/data/cosb3_fourier_baseline.toml
+++ b/reftest/data/cosb3_fourier_baseline.toml
@@ -1,0 +1,31 @@
+# CoSb3 Fourier path documented baseline (manual, frozen)
+#
+# BT.jl self-consistency regression record (NOT a Pizzi-conformance test):
+# corrected-lattice geometry + DFTK SCF + compute_bands[16,16,16] NSCF + pinv
+# Fourier interpolation + solve_transport. Frozen to detect future lattice /
+# interpolation regressions. Source jld2 is not shipped (needs a 295 MB SCF
+# checkpoint to recompute); the values below are the canonical numerical record.
+#
+# Lattice: reftest/data/geometries/cosb3.jl (a = 17.080296 Bohr).
+# Units: sigma_xx_tau in 10^6 S/m; tau = 10 fs; mu_eff in eV (rel. to intrinsic
+# Fermi level); temperature = 300 K; mesh = NSCF compute_bands [16,16,16].
+
+[metadata]
+material      = "CoSb3"
+temperature_K = 300
+tau_fs        = 10
+mesh          = "NSCF compute_bands [16,16,16]"
+generator     = "DFTK SCF + compute_bands NSCF + BoltzTraP.jl pinv Fourier"
+
+[anchors]
+# Valence plateau (Pizzi 2014 ~1.0e6 S/m; ~3% agreement)
+valence_mu_eff_eV       = -1.25
+valence_sigma_xx_tau    = 0.9779
+valence_pizzi_2014_ref  = 1.0
+# Gap-centre (≈0 by gap)
+mid_gap_mu_eff_eV       = 0.00
+mid_gap_sigma_xx_tau    = 0.0394
+
+[baseline]
+mu_eff_eV    = [-2.00, -1.75, -1.50, -1.25, -1.00, -0.75, -0.50, -0.25,  0.00,  0.25,  0.50,  0.75,  1.00,  1.25,  1.50,  1.75,  2.00]
+sigma_xx_tau = [ 0.1905, 0.4830, 0.7166, 0.9779, 0.4708, 0.3973, 0.1205, 0.0617, 0.0394, 0.0485, 0.1219, 0.3814, 0.7147, 0.8354, 1.3905, 0.8436, 0.8535]


### PR DESCRIPTION
Closes #79

## Test plan
- `reftest/data/cosb3_fourier_baseline.toml` parses (TOML; 17 μ_eff points; valence and mid-gap anchors match the baseline arrays)
- docs build clean (the new Validation subsection renders)