### PR TITLE
style: apply JuliaFormatter v2 formatting

### DIFF
--- a/src/describe.jl
+++ b/src/describe.jl
@@ -162,7 +162,7 @@ function _describe_file(file::String; io::IO = stdout)
     end
 
     return nothing
-end#= Helper function to format values for display =#
+end #= Helper function to format values for display =#
 
 function _format_value(v)
     if v isa AbstractFloat


### PR DESCRIPTION
## Test plan
- Applied JuliaFormatter v2.10.1 via `format(".")` locally; the only change is a single missing space before an inline comment in `src/describe.jl`.
- Confirm the Format CI job is green.