### PR TITLE
Add a shared run_integrate front door for both interpolators

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -32,6 +32,17 @@ AbstractBZSampling
 UniformMesh
 ```
 
+## Band interpolation
+
+`WannierInterpolator` is documented on the [Wannier path](@ref) page, since it
+only becomes available once `Wannier.jl` is loaded.
+
+```@docs
+AbstractInterpolator
+FourierInterpolator
+interpolate_velocities
+```
+
 ## Material data carrier
 
 `TransportSystem` collects material-dependent data that was previously

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -18,7 +18,7 @@ solve_transport
 | Axis | Abstract type | Concrete subtype(s) | Role |
 |---|---|---|---|
 | `sampling` | `AbstractBZSampling` | `UniformMesh` | How the BZ is sampled |
-| `interp` | `AbstractInterpolator` | `FourierInterpolator` | How band energies and velocities are evaluated |
+| `interp` | `AbstractInterpolator` | `FourierInterpolator`, `WannierInterpolator` | How band energies and velocities are evaluated |
 | `sys` | `TransportSystem` | (concrete struct) | Material data carrier |
 
 A new sampling or interpolator strategy can be added by introducing a
@@ -52,25 +52,39 @@ scattered across `InterpolationResult.metadata` and `BandData{ST}`:
 TransportSystem
 ```
 
-The `TransportSystem(::InterpolationResult)` convenience constructor
-extracts these fields from existing interpolation output, so callers
-that already have an `InterpolationResult` need not assemble the struct
-manually.
+Two convenience constructors assemble it from what a given interpolation
+path already has. `TransportSystem(::InterpolationResult)` reads the
+fields out of the interpolation metadata. `TransportSystem(::WannierInterpolator; fermi, nelect)`
+takes the lattice and the spin type from the interpolator and requires
+the rest, because the Wannier90 files do not carry it.
 
-## Backward compatibility
+## Entry API
 
-The legacy entry points
+`run_integrate` is the entry point for both interpolation paths:
+
+```julia
+run_integrate(interp::AbstractInterpolator, sys::TransportSystem; sampling = UniformMesh(), kwargs...)
+run_integrate(interp::AbstractInterpolator, sys::TransportSystem, mur::AbstractVector; kwargs...)
+```
+
+The call site is the same whichever interpolator is passed; only
+`typeof(interp)` selects the backend, and `result.metadata["interpolator"]`
+records which one ran. `solve_transport` stays public for callers that
+want to address the three dispatch axes directly.
+
+The Fourier path keeps its convenience forms
 
 ```julia
 run_integrate(interp::InterpolationResult; kwargs...)
 run_integrate(interp::InterpolationResult, mur::AbstractVector; kwargs...)
+run_integrate(input::String; kwargs...)
 ```
 
-are preserved as thin wrappers. They build a `TransportSystem` and
-`FourierInterpolator` from the `InterpolationResult` and delegate to
-`solve_transport(UniformMesh(), ...)`. The wrapper restores the original
-`metadata["source"]` value after the delegate returns. Output is
-bit-equal to the pre-refactor implementation under default arguments.
+which build the `TransportSystem` and the `FourierInterpolator` from the
+`InterpolationResult` themselves. They restore the original
+`metadata["source"]` value before the result is written out, which is why
+they do not route through the two-argument form. Output is bit-equal to
+the pre-refactor implementation under default arguments.
 
 ## Provenance metadata
 
@@ -80,7 +94,12 @@ produced the output:
 | Key | Example value | Source |
 |---|---|---|
 | `"sampling"` | `"UniformMesh"` | type name of the sampling argument |
+| `"sampling_nk"` | `(23, 23, 23)` | the k-grid the integration actually used |
 | `"interpolator"` | `"Fourier"` | type name of the interpolator argument with the `Interpolator` suffix stripped |
 
 These keys are stamped by `solve_transport` and survive JLD2 round-trip
 through `save_integrate` / `load_integrate`.
+
+`"sampling_nk"` is resolved per interpolator: the Fourier path reports the
+grid its interpolation basis fixes, the Wannier path reports the grid it
+was given.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ Julia implementation of [BoltzTraP2](https://www.imc.tuwien.ac.at/forschungsbere
     - **[CLI workflow](@ref "CLI Workflow")** (Command Line): Run from terminal with `boltztrap` command. No programming required.
     - **[API workflow](@ref "API Workflow")** (Julia Session): Call functions from Julia REPL or scripts. Suitable for customization and automation.
 
-    Both workflows produce identical results.
+    Both workflows call the same code paths and produce the same results.
 
 ### Available Commands
 
@@ -91,7 +91,7 @@ Then add to PATH: `export PATH="$HOME/.julia/bin:$PATH"`
 
 ## Compatibility with Python BoltzTraP2
 
-BoltzTraP.jl aims for numerical compatibility with Python BoltzTraP2. To ensure bit-for-bit compatibility with the reference implementation, BoltzTraP.jl uses explicit numerical constants for all unit conversions, avoiding potential discrepancies from unit libraries.
+BoltzTraP.jl aims for numerical compatibility with Python BoltzTraP2. To keep unit conversions from introducing discrepancies of their own, BoltzTraP.jl uses explicit numerical constants rather than a unit library.
 
 Key differences:
 

--- a/docs/src/integrate.md
+++ b/docs/src/integrate.md
@@ -29,6 +29,21 @@ transport = run_integrate("si_interp.jld2";
 save_integrate("si_transport.jld2", transport)
 ```
 
+### Other interpolators
+
+The same entry point takes any [`AbstractInterpolator`](@ref) together
+with the [`TransportSystem`](@ref) that supplies the Fermi energy, the
+electron count, the DOS weight and the spin type. See the
+[Wannier path](@ref) page for the Wannier interpolator.
+
+```julia
+using Wannier
+
+wi = WannierInterpolator("path/to/silicon")
+sys = TransportSystem(wi; fermi = 0.2, nelect = 8.0)
+transport = run_integrate(wi, sys; sampling = UniformMesh((8, 8, 8)))
+```
+
 ---
 
 ## Output: save/load

--- a/docs/src/reftest.md
+++ b/docs/src/reftest.md
@@ -6,7 +6,7 @@ These reference tests were used by the developers during implementation to ensur
 
 ## Overview
 
-Reference testing ensures BoltzTraP.jl produces results identical to the original Python implementation:
+Reference testing checks BoltzTraP.jl against the original Python implementation on a fixed set of cases:
 
 | Aspect | Description |
 |--------|-------------|

--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -16,7 +16,7 @@ BoltzTraP.jl was developed using **reference testing** - a methodology where:
 2. Julia BoltzTraP.jl computes the same quantities from the same inputs
 3. Results are compared to verify numerical equivalence
 
-This approach guarantees that BoltzTraP.jl produces results identical to the original Python implementation.
+On the cases covered by these tests, the two implementations agree to within `< 10⁻⁶` relative error. That is what the tests establish; they do not prove identity in general.
 
 ### Validation Summary
 

--- a/docs/src/wannier.md
+++ b/docs/src/wannier.md
@@ -8,17 +8,22 @@ in scope alongside `using BoltzTraP`.
 
 The extension exposes a [`WannierInterpolator`](@ref) type that
 implements the same [`AbstractInterpolator`](@ref) interface as the
-default Fourier (Shankland) path. Once constructed, it slots into the
-existing transport pipeline through
-[`solve_transport`](@ref)`(::UniformMesh, ::WannierInterpolator, sys)`.
+default Fourier (Shankland) path. Once constructed, it goes through the
+same entry point, [`run_integrate`](@ref)`(interp, sys; sampling)`.
 
 ```julia
 using BoltzTraP
 using Wannier
 
 wi = WannierInterpolator("path/to/silicon")          # prefix entry point
-result = solve_transport(UniformMesh((8, 8, 8)), wi, sys; temperatures = [300.0])
+sys = TransportSystem(wi; fermi = 0.2, nelect = 8.0)
+result = run_integrate(wi, sys; sampling = UniformMesh((8, 8, 8)), temperatures = [300.0])
 ```
+
+Only the interpolator changes between the two paths. What the Wannier
+path additionally needs — the Fermi energy, the electron count, and an
+explicit mesh — is visible in the call: the Wannier90 files carry the
+Hamiltonian, not the state of the electron system.
 
 ## Construction
 
@@ -58,37 +63,56 @@ directly from an SCF result.
 The prefix-string constructor is itself a thin wrapper around this
 method.
 
-## Use with `solve_transport`
+## Running a transport calculation
+
+### Building the system
+
+`TransportSystem` collects the material constants that the transport
+integrals need. The lattice and the spin type come from the
+interpolator; the Fermi energy and the electron count do not exist in
+the Wannier90 files and have to be supplied:
+
+```julia
+sys = TransportSystem(wi; fermi = 0.2, nelect = 8.0)   # fermi in Hartree
+```
+
+`dosweight` defaults to the spin degeneracy implied by the spin type,
+`2.0` when unpolarized and `1.0` otherwise.
 
 ### Basic usage
 
-The Wannier path participates in the standard transport pipeline:
+The Wannier path goes through the same entry point as the Fourier path:
 
 ```julia
-result = solve_transport(mesh::UniformMesh, wi::WannierInterpolator, sys::TransportSystem;
-                         temperatures = ..., ...)
+result = run_integrate(wi, sys; sampling = UniformMesh((8, 8, 8)),
+                       temperatures = [300.0])
 ```
 
-### `UniformMesh.nk` is required
+[`solve_transport`](@ref) remains available for callers that want to
+address the three dispatch axes directly.
 
-The Fourier path can derive a natural integration mesh from the
-symmetry-equivalent points that accompany the interpolation
-coefficients. The Wannier path has no such structure — the
-`Wannier.InterpModel` carries only the real-space Hamiltonian and the
-associated R-vectors — so the caller must supply an explicit k-mesh
-through `UniformMesh.nk`.
+### An explicit mesh size is required
+
+The Fourier path derives its integration grid from the star functions
+that accompany the interpolation coefficients. The Wannier path has no
+such structure — the `Wannier.InterpModel` carries only the real-space
+Hamiltonian and the associated R-vectors — so the caller must supply an
+explicit k-mesh.
 
 In practice this means `UniformMesh((nk1, nk2, nk3))` with concrete
 integers; a `UniformMesh` constructed with `nk === nothing` is rejected
 when paired with a `WannierInterpolator`.
 
 ```julia
-mesh = UniformMesh((8, 8, 8))                            # OK
-result = solve_transport(mesh, wi, sys; temperatures = [300.0])
-
-mesh_nothing = UniformMesh(nothing)                      # Fourier-only
-solve_transport(mesh_nothing, wi, sys; ...)              # errors
+result = run_integrate(wi, sys; sampling = UniformMesh((8, 8, 8)))  # OK
+run_integrate(wi, sys)                                              # errors
 ```
+
+The grid that was used is recorded in `result.metadata["sampling_nk"]`.
+
+Passing an explicit size on the Fourier path has the opposite outcome:
+the size is ignored, with a warning, because the interpolation basis
+already fixes the grid.
 
 ## Unit conventions
 

--- a/docs/src/workflow.md
+++ b/docs/src/workflow.md
@@ -28,30 +28,35 @@ See [Input Formats](@ref input-formats) for detailed format specifications.
 All workflows follow the same pattern:
 
 ```
-┌───────────────────────────────┐
-│         Data Source           │
-│ (VASP/QE/Wien2k/GENE/ABINIT/  │
-│  DFTK)                        │
-└───────────────┬───────────────┘
-                │ load_*() → DFTData
-                ▼
-┌───────────────────────────────┐
-│       run_interpolate         │
-│        (Fourier fit)          │
-└───────────────┬───────────────┘
-                │
-                ▼
-        InterpolationResult
-                │
-                ▼
-┌───────────────────────────────┐
-│        run_integrate          │
-│    (transport coefficients)   │
-└───────────────┬───────────────┘
-                │
-                ▼
-         TransportResult
+┌───────────────────────────────┐   ┌───────────────────────────────┐
+│         Data Source           │   │      Wannier90 files          │
+│ (VASP/QE/Wien2k/GENE/ABINIT/  │   │  (.chk and friends), or a     │
+│  DFTK)                        │   │  Wannier.InterpModel          │
+└───────────────┬───────────────┘   └───────────────┬───────────────┘
+                │ load_*() → DFTData                │
+                ▼                                   ▼
+┌───────────────────────────────┐   ┌───────────────────────────────┐
+│       run_interpolate         │   │      WannierInterpolator      │
+│        (Fourier fit)          │   │       (loads H(R))            │
+└───────────────┬───────────────┘   └───────────────┬───────────────┘
+                │                                   │
+                ▼                                   │
+        InterpolationResult                         │
+                │                                   │
+                ▼                                   ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                          run_integrate                          │
+│                    (transport coefficients)                     │
+└───────────────────────────┬─────────────────────────────────────┘
+                            │
+                            ▼
+                     TransportResult
 ```
+
+The Fourier path recovers the [`TransportSystem`](@ref) from the
+interpolation metadata, so `run_integrate(interp)` is enough. The Wannier
+path needs the system and an explicit mesh:
+`run_integrate(wi, sys; sampling = UniformMesh((8, 8, 8)))`.
 
 [`run_integrate`](@ref) accepts both [`InterpolationResult`](@ref) directly or a file path:
 

--- a/src/BoltzTraP.jl
+++ b/src/BoltzTraP.jl
@@ -108,8 +108,10 @@ export solve_transport
 export InterpolationResult, TransportResult
 export DFTData, NonMagneticData, SpinPolarizedData, nspin, is_magnetic
 
-# BZ sampling + Wannier interpolator
-export AbstractBZSampling, UniformMesh, TransportSystem, WannierInterpolator
+# BZ sampling + interpolators (the two dispatch axes of solve_transport)
+export AbstractBZSampling, UniformMesh, TransportSystem
+export AbstractInterpolator, FourierInterpolator, WannierInterpolator
+export interpolate_velocities
 
 # Spin types (v0.3 magnetic support)
 export SpinType, Unpolarized, Collinear, NonCollinear

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -9,19 +9,24 @@ using StaticArrays
 # Abstract Interpolator Interface
 # ============================================================================
 
-#=
+"""
     AbstractInterpolator
 
-Abstract type for band interpolation backends.
+Abstract type for band interpolation backends. It is the interpolator axis of
+[`solve_transport`](@ref) and of `run_integrate(interp, sys; sampling)`.
 
 Concrete implementations:
-- `FourierInterpolator`: BoltzTraP-style Fourier interpolation (eigenvalues only)
-- `WannierInterpolator`: Wannier.jl-based interpolation (provided by the Wannier.jl weakdep extension)
+
+  - [`FourierInterpolator`](@ref): BoltzTraP-style Fourier interpolation
+    (eigenvalues only)
+  - [`WannierInterpolator`](@ref): Wannier.jl-based interpolation (provided by
+    the Wannier.jl weakdep extension)
 
 Common API:
-- `interpolate_bands(interp, kpoints)` → eigenvalues
-- `interpolate_velocities(interp, kpoints)` → group velocities
-=#
+
+  - `interpolate_bands(interp, kpoints)` -> eigenvalues
+  - [`interpolate_velocities`](@ref)`(interp, kpoints)` -> group velocities
+"""
 abstract type AbstractInterpolator end
 
 #=
@@ -38,18 +43,24 @@ Interpolate band energies at given k-points.
 =#
 function interpolate_bands end
 
-#=
+"""
     interpolate_velocities(interp::AbstractInterpolator, kpoints)
 
-Interpolate group velocities at given k-points.
+Interpolate band group velocities at given k-points.
 
 # Arguments
-- `interp`: Interpolator instance
-- `kpoints`: Matrix of k-points (nk × 3) in fractional coordinates
+
+  - `interp`: an [`AbstractInterpolator`](@ref)
+  - `kpoints`: Matrix of k-points (nk × 3) in fractional coordinates
 
 # Returns
-- `vbands`: Group velocities (3 × nbands × nk)
-=#
+
+  - `vbands`: Group velocities (3 × nbands × nk), in Hartree·Bohr
+
+These are the band-diagonal group velocities. The degeneracy-aware,
+gauge-invariant velocity tensor used inside the transport pipeline is built
+separately from the full velocity matrices.
+"""
 function interpolate_velocities end
 
 #=
@@ -202,21 +213,29 @@ end
 # Fourier Interpolator (BoltzTraP method)
 # ============================================================================
 
-#=
+"""
     FourierInterpolator <: AbstractInterpolator
 
 BoltzTraP-style Fourier interpolation using star functions.
 
 # Fields
-- `coeffs`: Fourier coefficients (nbands × neq)
-- `equivalences`: Vector of equivalence class matrices
-- `lattvec`: 3×3 lattice vectors (columns)
 
-# Constructor
+  - `coeffs`: Fourier coefficients (nbands × neq)
+  - `equivalences`: Vector of equivalence class matrices
+  - `lattvec`: 3×3 lattice vectors (columns), in Bohr
+
+# Constructors
+
     FourierInterpolator(kpoints, energies, equivalences, lattvec)
+    FourierInterpolator(interp::InterpolationResult)
 
-Create interpolator by fitting band energies to Fourier series.
-=#
+The first fits band energies to a Fourier series. The second reuses the
+coefficients of an existing [`InterpolationResult`](@ref).
+
+The star functions fix the smallest grid that represents them exactly, so this
+interpolator derives its own integration grid and ignores an explicit
+[`UniformMesh`](@ref) size.
+"""
 struct FourierInterpolator <: AbstractInterpolator
     coeffs::Matrix{ComplexF64}
     equivalences::Vector{<:AbstractMatrix{<:Integer}}

--- a/src/io/serialization.jl
+++ b/src/io/serialization.jl
@@ -26,15 +26,15 @@ Container for interpolation results from [`run_interpolate`](@ref).
 
 # Metadata Keys
 
-  - `fermi_energy`: Fermi energy in Ha
+  - `fermi`: Fermi energy in Ha
   - `nelect`: Number of electrons
   - `dosweight`: DOS weight (2.0 for non-spin-polarized, 1.0 for collinear)
   - `spintype`: Spin type ("Unpolarized" or "Collinear")
   - `selected_bands`: Band indices used (UnitRange)
   - `spacegroup_number`: International space group number (1-230)
   - `spacegroup_symbol`: Space group symbol (e.g., "Fd-3m")
-  - `source_file`: Original DFT file path
-  - `creation_date`: ISO 8601 timestamp
+  - `source`: Original DFT file path
+  - `created`: ISO 8601 timestamp
   - `generator`: "BoltzTraP.jl"
 
 See also: [`run_interpolate`](@ref), [`run_integrate`](@ref), [`save_interpolation`](@ref), [`load_interpolation`](@ref)
@@ -139,13 +139,19 @@ Contains transport coefficients and other quantities computed by BZ integration.
 
 # Metadata Keys
 
-  - `fermi_energy`: Fermi energy in Ha
-  - `nelect`: Number of electrons
-  - `dosweight`: DOS weight (2.0 for non-spin-polarized, 1.0 for collinear)
-  - `spintype`: Spin type ("Unpolarized" or "Collinear")
-  - `source_file`: Original DFT file path
-  - `creation_date`: ISO 8601 timestamp
-  - Additional keys from interpolation step are preserved
+Stamped by [`solve_transport`](@ref):
+
+  - `interpolator`: `"Fourier"` or `"Wannier"`
+  - `sampling`: name of the BZ sampling type, e.g. `"UniformMesh"`
+  - `nelect`, `dosweight`, `spintype`: system constants used for the integration
+  - `fermi_Ha`, `fermi_eV`: Fermi energy of the interpolated bands
+  - `nbands`, `npts_fft`, `npts_dos`: grid sizes
+  - further provenance keys, and `scissor_eV` / `scissor_Ha` when a scissor
+    correction is applied
+
+Carried over from the interpolation metadata by [`run_integrate`](@ref):
+
+  - `source`: Original DFT file path
 
 See also: [`run_integrate`](@ref), [`save_integrate`](@ref), [`load_integrate`](@ref)
 """

--- a/src/io/serialization.jl
+++ b/src/io/serialization.jl
@@ -103,6 +103,24 @@ function TransportSystem(interp::InterpolationResult)
 end
 
 """
+    FourierInterpolator(interp::InterpolationResult) -> FourierInterpolator
+
+Build a `FourierInterpolator` from an `InterpolationResult`, reusing the
+stored Fourier coefficients, equivalence classes, and lattice vectors.
+
+The inverse direction is [`InterpolationResult`](@ref)`(::FourierInterpolator)`,
+which bundles an interpolator together with atoms and metadata for
+serialization.
+"""
+function FourierInterpolator(interp::InterpolationResult)
+    return FourierInterpolator(
+        interp.coeffs,
+        interp.equivalences,
+        SMatrix{3,3,Float64}(interp.lattvec),
+    )
+end
+
+"""
     TransportResult
 
 Container for transport coefficients from [`run_integrate`](@ref).

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -19,12 +19,17 @@ abstract type AbstractBZSampling end
     UniformMesh(nk=nothing)
     UniformMesh((nk1, nk2, nk3))
 
-Uniform Monkhorst-Pack-style mesh. The `nk` field selects the mesh density:
+Uniform Monkhorst-Pack-style mesh. The `nk` field asks for a mesh density:
 
-  - `nk === nothing`: the interpolator decides the mesh size (matches the
-    legacy `run_integrate` behavior, which derives the mesh from the
-    interpolator's k-point density).
-  - `nk::Tuple{Int,Int,Int}`: explicit user-specified mesh dimensions.
+  - `nk === nothing`: let the interpolator choose the mesh size.
+  - `nk::Tuple{Int,Int,Int}`: an explicit mesh size.
+
+Whether an explicit size is honoured depends on the interpolator. The Wannier
+path requires one and raises an error without it. The Fourier path takes its
+grid from the interpolation basis, where the star functions fix the smallest
+grid that represents them exactly, and warns that an explicit size is ignored.
+
+The grid actually used is recorded in `TransportResult.metadata["sampling_nk"]`.
 """
 struct UniformMesh <: AbstractBZSampling
     nk::Union{Nothing,Tuple{Int,Int,Int}}

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -88,6 +88,33 @@ struct WannierInterpolator{ST<:SpinType} <: AbstractInterpolator
     spintype::ST
 end
 
+"""
+    TransportSystem(wi::WannierInterpolator; fermi, nelect, spintype, dosweight)
+
+Build a [`TransportSystem`](@ref) from a `WannierInterpolator`.
+
+The lattice and the spin type are taken from `wi`. The Fermi energy and the
+electron count are not present in the Wannier90 files, so they have no default
+and must be supplied by the caller.
+
+# Keyword Arguments
+
+  - `fermi`: Fermi energy in Ha (required)
+  - `nelect`: number of electrons per unit cell (required)
+  - `spintype=wi.spintype`: spin type carried by the interpolator
+  - `dosweight`: DOS weight; defaults to the spin degeneracy implied by
+    `spintype`, i.e. `2.0` for `Unpolarized()` and `1.0` otherwise
+"""
+function TransportSystem(
+    wi::WannierInterpolator;
+    fermi::Real,
+    nelect::Real,
+    spintype::SpinType = wi.spintype,
+    dosweight::Real = (spintype isa Unpolarized ? 2.0 : 1.0),
+)
+    return TransportSystem(wi.lattice, fermi, nelect, dosweight, spintype)
+end
+
 # Stub: file-load constructor; the real method lives in BoltzTraPWannierExt.
 # The signature is `(args...; kwargs...)` — less specific than the extension's
 # `(prefix::String; spintype)` — so Julia dispatches to the extension method

--- a/src/solve_transport.jl
+++ b/src/solve_transport.jl
@@ -68,6 +68,12 @@ function solve_transport(
     scissor::Union{Nothing,Real} = nothing,
     verbose::Bool = false,
 )::TransportResult
+    isnothing(sampling.nk) || @warn(
+        "solve_transport: the Fourier path takes its integration grid from the " *
+        "interpolation basis, so the requested UniformMesh size is ignored.",
+        requested = sampling.nk,
+        used = determine_fft_dims(interp.equivalences),
+    )
     eband, vvband = getBTPbands(interp.coeffs, interp.equivalences, interp.lattvec)
     return _solve_transport_from_bands(
         eband,
@@ -114,6 +120,19 @@ end
 # matching shape — `(nbands, npts)` and `(nbands, 3, 3, npts)` — into
 # this helper, so output is bit-equal to the prior monolithic Fourier
 # implementation under default kwargs.
+#=
+    integration_grid(interp, sampling) -> Union{Nothing,NTuple{3,Int}}
+
+The k-grid that the integration actually used. The Fourier path takes it from
+the interpolation basis, whose star functions fix the smallest grid that
+represents them exactly; the Wannier path takes it from the sampling, which
+must carry an explicit `nk`.
+=#
+integration_grid(::AbstractInterpolator, sampling::AbstractBZSampling) = sampling.nk
+
+integration_grid(interp::FourierInterpolator, ::UniformMesh) =
+    determine_fft_dims(interp.equivalences)
+
 function _solve_transport_from_bands(
     eband::AbstractMatrix{<:Real},
     vvband::AbstractArray{<:Real,4},
@@ -202,6 +221,7 @@ function _solve_transport_from_bands(
     result_metadata = Dict{String,Any}(
         "source" => "solve_transport",
         "sampling" => string(nameof(typeof(sampling))),
+        "sampling_nk" => integration_grid(interp, sampling),
         "interpolator" => replace(string(nameof(typeof(interp))), "Interpolator" => ""),
         "nelect" => nelect,
         "dosweight" => dosweight,

--- a/src/workflow.jl
+++ b/src/workflow.jl
@@ -458,23 +458,54 @@ function run_interpolate(
     )
 end
 
+#=
+    _save_and_report(result, output, verbose) -> TransportResult
+
+Shared tail of every `run_integrate` method: write the result when an output
+path is given, then report completion. Callers that need to fix up
+`result.metadata` must do so before calling this, otherwise the saved file and
+the returned object disagree.
+=#
+function _save_and_report(result, output, verbose)
+    if !isnothing(output)
+        verbose && println("Saving to $output...")
+        save_integrate(output, result)
+    end
+    verbose && println("Done.")
+    return result
+end
+
 """
+    run_integrate(interp::AbstractInterpolator, sys::TransportSystem; kwargs...) -> TransportResult
+    run_integrate(interp::AbstractInterpolator, sys::TransportSystem, mur; kwargs...) -> TransportResult
     run_integrate(interp::InterpolationResult; kwargs...) -> TransportResult
     run_integrate(interp::InterpolationResult, mur; kwargs...) -> TransportResult
     run_integrate(input::String; kwargs...) -> TransportResult
     run_integrate(input::String, mur; kwargs...) -> TransportResult
 
-Compute transport coefficients from interpolation result.
+Compute transport coefficients.
+
+The first form is the general entry point: it takes any
+[`AbstractInterpolator`](@ref) together with the [`TransportSystem`](@ref) that
+supplies the Fermi energy, the electron count, the DOS weight and the spin
+type. The remaining forms are conveniences for the Fourier path, which can
+recover the system from the interpolation metadata.
 
 # Arguments
 
-  - `interp`: [`InterpolationResult`](@ref) from [`run_interpolate`](@ref)
+  - `interp`: an [`AbstractInterpolator`](@ref), or an [`InterpolationResult`](@ref)
+    from [`run_interpolate`](@ref)
+  - `sys`: [`TransportSystem`](@ref) holding the system constants
   - `input`: Path to interpolation result file (.jld2) - alternative to `interp`
   - `mur`: Chemical potential values in Hartree (positional argument, optional).
     Same name as Python BoltzTraP2 for compatibility.
 
 # Keyword Arguments
 
+  - `sampling=UniformMesh()`: how the Brillouin zone is sampled. Only the
+    `(interp, sys)` forms accept it. The Wannier path needs an explicit mesh
+    size, e.g. `UniformMesh((8, 8, 8))`; the Fourier path derives its own grid
+    from the interpolation basis and ignores this argument.
   - `temperatures=[300.0]`: Vector of temperatures in K
   - `output=nothing`: Output file path (no file saved if `nothing`)
   - `bins=0`: Number of DOS histogram bins (auto if `0`)
@@ -490,7 +521,7 @@ Compute transport coefficients from interpolation result.
 # Examples
 
 ```julia
-# Direct from InterpolationResult (μ auto-generated)
+# Fourier path: the system is recovered from the interpolation metadata
 interp = run_interpolate("./Si.vasp")
 transport = run_integrate(interp; temperatures = [300.0])
 
@@ -503,10 +534,51 @@ transport = run_integrate(interp, mur; temperatures = [300.0])
 
 # With scissor correction (shift conduction bands to 1.1 eV gap)
 transport = run_integrate(interp; temperatures = [300.0], scissor = 1.1)
+
+# Wannier path: the system and the mesh have to be supplied
+using Wannier
+wi = WannierInterpolator("path/to/silicon")
+sys = TransportSystem(wi; fermi = εF, nelect = 8.0)
+transport = run_integrate(wi, sys; sampling = UniformMesh((8, 8, 8)))
 ```
 
-See also: [`run_interpolate`](@ref), [`save_integrate`](@ref), [`apply_scissor`](@ref)
+See also: [`run_interpolate`](@ref), [`solve_transport`](@ref),
+[`save_integrate`](@ref), [`apply_scissor`](@ref)
 """
+function run_integrate(
+    interp::AbstractInterpolator,
+    sys::TransportSystem;
+    sampling::AbstractBZSampling = UniformMesh(),
+    temperatures::AbstractVector{<:Real} = [300.0],
+    output::Union{String,Nothing} = nothing,
+    bins::Int = 0,
+    scissor::Union{Nothing,Real} = nothing,
+    verbose::Bool = false,
+)
+    @debug "run_integrate(interp, sys) called" sampling temperatures output bins scissor verbose
+
+    result = solve_transport(sampling, interp, sys; temperatures, bins, scissor, verbose)
+    return _save_and_report(result, output, verbose)
+end
+
+function run_integrate(
+    interp::AbstractInterpolator,
+    sys::TransportSystem,
+    mur::AbstractVector{<:Real};
+    sampling::AbstractBZSampling = UniformMesh(),
+    temperatures::AbstractVector{<:Real} = [300.0],
+    output::Union{String,Nothing} = nothing,
+    bins::Int = 0,
+    scissor::Union{Nothing,Real} = nothing,
+    verbose::Bool = false,
+)
+    @debug "run_integrate(interp, sys, mur) called" sampling temperatures output bins scissor verbose
+
+    result =
+        solve_transport(sampling, interp, sys; temperatures, mur, bins, scissor, verbose)
+    return _save_and_report(result, output, verbose)
+end
+
 function run_integrate(
     interp::InterpolationResult;
     temperatures::AbstractVector{<:Real} = [300.0],
@@ -522,16 +594,11 @@ function run_integrate(
 
     result = solve_transport(UniformMesh(), fi, sys; temperatures, bins, scissor, verbose)
 
-    # Restore source provenance from the interpolation metadata.
+    # Restore source provenance from the interpolation metadata, before the
+    # result is written out.
     result.metadata["source"] = get(interp.metadata, "source", "unknown")
 
-    if !isnothing(output)
-        verbose && println("Saving to $output...")
-        save_integrate(output, result)
-    end
-
-    verbose && println("Done.")
-    return result
+    return _save_and_report(result, output, verbose)
 end
 
 # Method with explicit μ grid (positional argument)
@@ -554,13 +621,7 @@ function run_integrate(
 
     result.metadata["source"] = get(interp.metadata, "source", "unknown")
 
-    if !isnothing(output)
-        verbose && println("Saving to $output...")
-        save_integrate(output, result)
-    end
-
-    verbose && println("Done.")
-    return result
+    return _save_and_report(result, output, verbose)
 end
 
 # File-based convenience method (μ auto-generated)

--- a/src/workflow.jl
+++ b/src/workflow.jl
@@ -518,11 +518,7 @@ function run_integrate(
     @debug "run_integrate called" temperatures output bins scissor verbose
 
     sys = TransportSystem(interp)
-    fi = FourierInterpolator(
-        interp.coeffs,
-        interp.equivalences,
-        SMatrix{3,3,Float64}(interp.lattvec),
-    )
+    fi = FourierInterpolator(interp)
 
     result = solve_transport(UniformMesh(), fi, sys; temperatures, bins, scissor, verbose)
 
@@ -551,11 +547,7 @@ function run_integrate(
     @debug "run_integrate(interp, mur) called" temperatures output bins scissor verbose
 
     sys = TransportSystem(interp)
-    fi = FourierInterpolator(
-        interp.coeffs,
-        interp.equivalences,
-        SMatrix{3,3,Float64}(interp.lattvec),
-    )
+    fi = FourierInterpolator(interp)
 
     result =
         solve_transport(UniformMesh(), fi, sys; temperatures, mur, bins, scissor, verbose)

--- a/src/workflow.jl
+++ b/src/workflow.jl
@@ -523,7 +523,7 @@ function run_integrate(
     result = solve_transport(UniformMesh(), fi, sys; temperatures, bins, scissor, verbose)
 
     # Restore source provenance from the interpolation metadata.
-    result.metadata["source"] = get(interp.metadata, "source_file", "unknown")
+    result.metadata["source"] = get(interp.metadata, "source", "unknown")
 
     if !isnothing(output)
         verbose && println("Saving to $output...")
@@ -552,7 +552,7 @@ function run_integrate(
     result =
         solve_transport(UniformMesh(), fi, sys; temperatures, mur, bins, scissor, verbose)
 
-    result.metadata["source"] = get(interp.metadata, "source_file", "unknown")
+    result.metadata["source"] = get(interp.metadata, "source", "unknown")
 
     if !isnothing(output)
         verbose && println("Saving to $output...")

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -316,6 +316,54 @@ end
     end
 end
 
+@testset "integration grid on the Fourier path" begin
+    datadir = joinpath(@__DIR__, "..", "benchmarks", "data", "Si.vasp")
+    have_data = isdir(datadir) && isfile(joinpath(datadir, "vasprun.xml"))
+
+    @testset "an explicit mesh size warns and is ignored" begin
+        if have_data
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            fi = BoltzTraP.FourierInterpolator(ir)
+            sys = BoltzTraP.TransportSystem(ir)
+
+            derived = solve_transport(UniformMesh(), fi, sys; temperatures = [300.0])
+            requested = @test_logs (:warn,) match_mode = :any solve_transport(
+                UniformMesh((8, 8, 8)),
+                fi,
+                sys;
+                temperatures = [300.0],
+            )
+            # The warning is the only effect: the grid comes from the basis.
+            @test requested.sigma == derived.sigma
+            @test requested.metadata["sampling_nk"] == derived.metadata["sampling_nk"]
+
+            # The default mesh must stay silent.
+            @test_logs solve_transport(UniformMesh(), fi, sys; temperatures = [300.0])
+        else
+            @warn "Skipping explicit mesh warning test: data not found at $datadir"
+        end
+    end
+
+    @testset "sampling_nk records the grid that was used" begin
+        if have_data
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            dims = BoltzTraP.determine_fft_dims(ir.equivalences)
+            result = BoltzTraP.run_integrate(ir; temperatures = [300.0])
+
+            @test result.metadata["sampling_nk"] == dims
+            @test prod(result.metadata["sampling_nk"]) == result.metadata["npts_fft"]
+
+            mktempdir() do dir
+                path = joinpath(dir, "sampling_nk_roundtrip.jld2")
+                save_integrate(path, result)
+                @test load_integrate(path).metadata["sampling_nk"] == dims
+            end
+        else
+            @warn "Skipping sampling_nk test: data not found at $datadir"
+        end
+    end
+end
+
 @testset "provenance metadata" begin
     datadir = joinpath(@__DIR__, "..", "benchmarks", "data", "Si.vasp")
     have_data = isdir(datadir) && isfile(joinpath(datadir, "vasprun.xml"))

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -104,6 +104,25 @@ end
     end
 end
 
+@testset "FourierInterpolator from InterpolationResult" begin
+    coeffs = ComplexF64[1.0+0im 2.0+0im; 3.0+0im 4.0+0im]
+    equivs = [reshape([0, 0, 0], 1, 3), reshape([1, 0, 0], 1, 3)]
+    lattvec = 5.0 * Matrix{Float64}(LinearAlgebra.I, 3, 3)
+    ir = BoltzTraP.InterpolationResult(coeffs, equivs, lattvec, nothing, Dict{String,Any}())
+
+    fi_manual = BoltzTraP.FourierInterpolator(
+        ir.coeffs,
+        ir.equivalences,
+        SMatrix{3,3,Float64}(ir.lattvec),
+    )
+    fi_conv = BoltzTraP.FourierInterpolator(ir)
+
+    @test fi_conv isa BoltzTraP.FourierInterpolator
+    @test fi_conv.coeffs == fi_manual.coeffs
+    @test fi_conv.equivalences == fi_manual.equivalences
+    @test fi_conv.lattvec == fi_manual.lattvec
+end
+
 # Helper: dummy AbstractBZSampling subtype for abstract-type fallback test
 struct _DummyBZSampling <: BoltzTraP.AbstractBZSampling end
 

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -220,6 +220,9 @@ end
             # source must come from IR metadata (wrapper restores), not the
             # solve_transport delegate's hardcoded "solve_transport".
             @test result.metadata["source"] != "solve_transport"
+            # ... and it must be the value the interpolation stage recorded,
+            # not the "unknown" fallback.
+            @test result.metadata["source"] == ir.metadata["source"]
             @test haskey(result.metadata, "fermi_Ha")
             @test haskey(result.metadata, "vuc_ang3")
         else
@@ -238,6 +241,7 @@ end
             @test length(result.mu_values) == length(mur_test)
             @test !any(isnan, result.sigma)
             @test result.metadata["source"] != "solve_transport"
+            @test result.metadata["source"] == ir.metadata["source"]
         else
             @warn "Skipping run_integrate explicit-μ wrapper test: data not found at $datadir"
         end

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -47,6 +47,22 @@ struct _DummySubtypeInterp <: BoltzTraP.AbstractInterpolator end
     end
 end
 
+@testset "public API surface" begin
+    exported = names(BoltzTraP)
+
+    # The interpolator axis is part of the documented entry point
+    # run_integrate(interp, sys; sampling), so its types and the velocity
+    # accessor are public.
+    @test :AbstractInterpolator in exported
+    @test :FourierInterpolator in exported
+    @test :WannierInterpolator in exported
+    @test :interpolate_velocities in exported
+
+    # `interpolate` is exported by Wannier.jl; exporting it here would clash
+    # under `using BoltzTraP, Wannier`.
+    @test !(:interpolate in exported)
+end
+
 @testset "TransportSystem" begin
     # Synthetic InterpolationResult helpers (avoid heavy run_interpolate path)
     function _synth_interp(;

--- a/test/test_sampling.jl
+++ b/test/test_sampling.jl
@@ -248,6 +248,74 @@ end
     end
 end
 
+@testset "run_integrate (interpolator + system)" begin
+    datadir = joinpath(@__DIR__, "..", "benchmarks", "data", "Si.vasp")
+    have_data = isdir(datadir) && isfile(joinpath(datadir, "vasprun.xml"))
+
+    @testset "canonical form reproduces the wrapper" begin
+        if have_data
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            wrapped = BoltzTraP.run_integrate(ir; temperatures = [300.0])
+            canonical = BoltzTraP.run_integrate(
+                BoltzTraP.FourierInterpolator(ir),
+                BoltzTraP.TransportSystem(ir);
+                temperatures = [300.0],
+            )
+
+            @test canonical.sigma == wrapped.sigma
+            @test canonical.seebeck == wrapped.seebeck
+            @test canonical.kappa == wrapped.kappa
+            @test canonical.mu_values == wrapped.mu_values
+
+            # Only the wrapper knows the interpolation metadata, so only the
+            # wrapper can restore the source. The canonical form leaves the
+            # value stamped by solve_transport.
+            @test wrapped.metadata["source"] == ir.metadata["source"]
+            @test canonical.metadata["source"] == "solve_transport"
+        else
+            @warn "Skipping canonical run_integrate test: data not found at $datadir"
+        end
+    end
+
+    @testset "canonical form with explicit μ grid" begin
+        if have_data
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            mur_test = collect(0.0:0.05:0.5)
+            wrapped = BoltzTraP.run_integrate(ir, mur_test; temperatures = [300.0])
+            canonical = BoltzTraP.run_integrate(
+                BoltzTraP.FourierInterpolator(ir),
+                BoltzTraP.TransportSystem(ir),
+                mur_test;
+                temperatures = [300.0],
+            )
+
+            @test canonical.sigma == wrapped.sigma
+            @test canonical.mu_values == wrapped.mu_values
+        else
+            @warn "Skipping canonical run_integrate mur test: data not found at $datadir"
+        end
+    end
+
+    @testset "sampling keyword is forwarded to solve_transport" begin
+        if have_data
+            ir = BoltzTraP.run_interpolate(datadir; kpoints = 200, verbose = false)
+            fi = BoltzTraP.FourierInterpolator(ir)
+            sys = BoltzTraP.TransportSystem(ir)
+            default_mesh = BoltzTraP.run_integrate(fi, sys; temperatures = [300.0])
+            explicit_mesh = BoltzTraP.run_integrate(
+                fi,
+                sys;
+                sampling = UniformMesh(),
+                temperatures = [300.0],
+            )
+            @test explicit_mesh.sigma == default_mesh.sigma
+            @test default_mesh.metadata["sampling"] == "UniformMesh"
+        else
+            @warn "Skipping sampling keyword test: data not found at $datadir"
+        end
+    end
+end
+
 @testset "provenance metadata" begin
     datadir = joinpath(@__DIR__, "..", "benchmarks", "data", "Si.vasp")
     have_data = isdir(datadir) && isfile(joinpath(datadir, "vasprun.xml"))

--- a/test/test_wannier_ext.jl
+++ b/test/test_wannier_ext.jl
@@ -102,6 +102,33 @@ using Wannier
         end
     end
 
+    @testset "TransportSystem from WannierInterpolator" begin
+        wi = WannierInterpolator(sifix)
+        sys_manual = TransportSystem(wi.lattice, 0.2, 8.0, 2.0, Unpolarized())
+        sys_conv = TransportSystem(wi; fermi = 0.2, nelect = 8.0)
+
+        @test sys_conv.lattice == sys_manual.lattice
+        @test sys_conv.fermi == sys_manual.fermi
+        @test sys_conv.nelect == sys_manual.nelect
+        # lattice and spintype come from the interpolator; fermi and nelect
+        # are not in the Wannier90 files and must be supplied by the caller.
+        @test sys_conv.spintype isa Unpolarized
+        @test sys_conv.dosweight == 2.0
+
+        # dosweight defaults to the spin degeneracy implied by spintype:
+        # 2.0 when unpolarized, 1.0 otherwise.
+        wi_collinear =
+            BoltzTraP.WannierInterpolator{Collinear}(wi.model, wi.lattice, Collinear())
+        sys_collinear = TransportSystem(wi_collinear; fermi = 0.2, nelect = 8.0)
+        @test sys_collinear.spintype isa Collinear
+        @test sys_collinear.dosweight == 1.0
+
+        # An explicit dosweight overrides the default.
+        sys_override = TransportSystem(wi; fermi = 0.2, nelect = 8.0, dosweight = 1.0)
+        @test sys_override.dosweight == 1.0
+        @test sys_override.spintype isa Unpolarized
+    end
+
     @testset "solve_transport smoke (UniformMesh + WannierInterpolator)" begin
         wi = WannierInterpolator(sifix)
         # Mock TransportSystem for Si: 8 valence electrons, dosweight 2.0,

--- a/test/test_wannier_ext.jl
+++ b/test/test_wannier_ext.jl
@@ -142,4 +142,22 @@ using Wannier
         @test size(result.sigma)[1:3] == (3, 3, 1)
         @test size(result.sigma, 4) > 0
     end
+
+    @testset "run_integrate (UniformMesh + WannierInterpolator)" begin
+        wi = WannierInterpolator(sifix)
+        sys = TransportSystem(wi; fermi = 0.2, nelect = 8.0)
+        mesh = UniformMesh((4, 4, 4))
+
+        hub = run_integrate(wi, sys; sampling = mesh, temperatures = [300.0])
+        direct = solve_transport(mesh, wi, sys; temperatures = [300.0])
+
+        @test hub.sigma == direct.sigma
+        @test hub.seebeck == direct.seebeck
+        @test hub.kappa == direct.kappa
+        @test hub.metadata["interpolator"] == "Wannier"
+
+        # The Wannier path cannot derive a mesh, so the default sampling is
+        # rejected rather than silently guessed.
+        @test_throws ErrorException run_integrate(wi, sys; temperatures = [300.0])
+    end
 end

--- a/test/test_wannier_ext.jl
+++ b/test/test_wannier_ext.jl
@@ -155,6 +155,9 @@ using Wannier
         @test hub.seebeck == direct.seebeck
         @test hub.kappa == direct.kappa
         @test hub.metadata["interpolator"] == "Wannier"
+        # The Wannier path takes the grid from the sampling, so that is what
+        # gets recorded.
+        @test hub.metadata["sampling_nk"] == (4, 4, 4)
 
         # The Wannier path cannot derive a mesh, so the default sampling is
         # rejected rather than silently guessed.


### PR DESCRIPTION
Closes #87, #88, #89, #90, #91

## Test plan

- `TEST_WANNIER=true julia --project -e 'using Pkg; Pkg.test(test_args=["core"])'`
  on Julia 1.10 and 1.11: 1664 passed, 3 broken.
- `TEST_WANNIER=true julia --project -e 'using Pkg; Pkg.test(test_args=["ext"])'`
  on Julia 1.10 and 1.11: 177 passed.
- Transport output on benchmarks/data/Si.vasp is bit-equal to main for both
  `run_integrate(ir)` and `run_integrate(ir, mur)`. The only metadata that
  changes is `"source"`, which was always `"unknown"` before (#91).
- `julia --project=docs docs/make.jl` builds with no new warnings.
- Saving through `output=` writes the same `"source"` the returned result
  carries, and `verbose=true` still prints `Saving to ...` before `Done.`.
