### PR TITLE
Prepare v0.4.1 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
     email: hsugawa@gmail.com
 repository-code: "https://github.com/hsugawa8651/BoltzTraP.jl"
 license: GPL-3.0-or-later
-version: 0.4.0
-date-released: 2026-05-31
+version: 0.4.1
+date-released: 2026-07-10
 doi: "10.5281/zenodo.20469759"
 keywords:
   - band structure

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "BoltzTraP"
 uuid = "cbda18ea-c181-4d25-a1c9-354b8a2900c6"
 license = "GPL-3.0-or-later"
 authors = ["Hiroharu Sugawara <hsugawa@gmail.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 CodecXz = "ba30903b-d9e8-5048-a5ec-d1f5b0d4b47b"

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Bug reports and feature requests are welcome via [GitHub Issues](https://github.
 If you use BoltzTraP.jl in your research, please cite the following:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.4.0) [Computer software]. https://doi.org/10.5281/zenodo.20469759
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.4.1) [Computer software]. https://doi.org/10.5281/zenodo.20469759
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -103,7 +103,7 @@ Key differences:
 If you use BoltzTraP.jl in your research, please cite the following:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.4.0) [Computer software]. [doi:10.5281/zenodo.20469759](https://doi.org/10.5281/zenodo.20469759)
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.4.1) [Computer software]. [doi:10.5281/zenodo.20469759](https://doi.org/10.5281/zenodo.20469759)
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)


### PR DESCRIPTION
## Test plan
- version strings bumped to 0.4.1 (`git grep 0.4.0` = 0 across the repository)
- version DOI intentionally left at v0.4.0's until the post-tag DOI update PR; concept-DOI badge unchanged
- `date-released` set to the planned release date, 2026-07-10
- CI green
