### PR TITLE
docs: update DOI to v0.4.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ repository-code: "https://github.com/hsugawa8651/BoltzTraP.jl"
 license: GPL-3.0-or-later
 version: 0.4.1
 date-released: 2026-07-10
-doi: "10.5281/zenodo.20469759"
+doi: "10.5281/zenodo.21298549"
 keywords:
   - band structure
   - interpolation

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Bug reports and feature requests are welcome via [GitHub Issues](https://github.
 If you use BoltzTraP.jl in your research, please cite the following:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.4.1) [Computer software]. https://doi.org/10.5281/zenodo.20469759
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.4.1) [Computer software]. https://doi.org/10.5281/zenodo.21298549
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -103,7 +103,7 @@ Key differences:
 If you use BoltzTraP.jl in your research, please cite the following:
 
 **BoltzTraP.jl:**
-> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.4.1) [Computer software]. [doi:10.5281/zenodo.20469759](https://doi.org/10.5281/zenodo.20469759)
+> Sugawara, H. (2026). BoltzTraP.jl: Julia port of BoltzTraP2 for band structure interpolation and transport coefficient calculation (Version 0.4.1) [Computer software]. [doi:10.5281/zenodo.21298549](https://doi.org/10.5281/zenodo.21298549)
 
 **Original BoltzTraP2:**
 > Madsen, G. K., Carrete, J., & Verstraete, M. J. (2018). BoltzTraP2, a program for interpolating band structures and calculating semi-classical transport coefficients. *Computer Physics Communications*, 231, 140-145. [doi:10.1016/j.cpc.2018.05.010](https://doi.org/10.1016/j.cpc.2018.05.010)


### PR DESCRIPTION
## Test plan
- version DOI updated to the v0.4.1 Zenodo record (10.5281/zenodo.21298549)
